### PR TITLE
Revised FormDisplay, validateFormData behavior

### DIFF
--- a/src/components/PlayerMultiSelect.js
+++ b/src/components/PlayerMultiSelect.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-export default function PlayerMultiSelect({ name, players, onChange, value }) {
+export default function PlayerMultiSelect({ name, players, onChange, value, header = '' }) {
   const onAdd = (e) => {
     onChange({ target: { name, value: [...value, Number(e.target.value)] } });
   };
@@ -15,33 +15,38 @@ export default function PlayerMultiSelect({ name, players, onChange, value }) {
   }, [players]);
 
   return (
-    <div>
-      <select className="player-select" name={name} onChange={onAdd}>
-        <option value="null">Add Player</option>
-        {players
-          .filter((player) => !value.includes(player.id))
-          .sort((a, b) => a.lastName.localeCompare(b.lastName))
-          .map((player) => (
-            <option key={player.id} value={player.id}>
-              {player.lastName}, {player.firstName[0]}. #{player.jerseyNumber}
-            </option>
-          ))}
-      </select>
-      {value.map((pd) => {
-        const index = players.findIndex((p) => p.id === pd);
-        return (
-          index >= 0 && (
-            <div key={pd}>
-              <p>
-                {players[index].lastName}, {players[index].firstName[0]}. #{players[index].jerseyNumber}
-              </p>
-              <button type="button" onClick={() => onRemove(players[index].id)}>
-                X
-              </button>
-            </div>
-          )
-        );
-      })}
+    <div className="player-multi">
+      <div className="player-multi-header">
+        {header !== '' && <p>{header}</p>}
+        <select className="player-select" name={name} onChange={onAdd} disabled={value.length === players.length}>
+          <option value="null">Select Player</option>
+          {players
+            .filter((player) => !value.includes(player.id))
+            .sort((a, b) => a.lastName.localeCompare(b.lastName))
+            .map((player) => (
+              <option key={player.id} value={player.id}>
+                {player.lastName}, {player.firstName[0]}. #{player.jerseyNumber}
+              </option>
+            ))}
+        </select>
+      </div>
+      <div className="player-multi-collection">
+        {value.map((pd) => {
+          const index = players.findIndex((p) => p.id === pd);
+          return (
+            index >= 0 && (
+              <div key={pd} className="player-multi-collection-item">
+                <button type="button" onClick={() => onRemove(players[index].id)}>
+                  X
+                </button>
+                <p>
+                  {players[index].lastName}, {players[index].firstName[0]}. #{players[index].jerseyNumber}
+                </p>
+              </div>
+            )
+          );
+        })}
+      </div>
     </div>
   );
 }
@@ -58,4 +63,5 @@ PlayerMultiSelect.propTypes = {
   ).isRequired,
   onChange: PropTypes.func.isRequired,
   value: PropTypes.arrayOf(PropTypes.number).isRequired,
+  header: PropTypes.string,
 };

--- a/src/components/forms/PlayForm.js
+++ b/src/components/forms/PlayForm.js
@@ -100,12 +100,15 @@ const initialDisplay = {
   kickoff: false,
   fieldGoal: false,
   punt: false,
-  kickBlock: false,
+  kickBlocked: false,
   interception: false,
   fakeToPass: false,
   fakeToRush: false,
   twoPointPass: false,
   twoPointRush: false,
+  lateralCreator: false,
+  fumbleCreator: false,
+  penaltyCreator: false,
 };
 
 // const retainPlay = {
@@ -439,7 +442,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     setFormData((prev) => ({ ...prev, ...resetValues }));
   };
 
-  const validatedFormData = () => {
+  const validateFormData = () => {
     // fieldPositionStart, teamId, gameId cannot be null
     if (formData.fieldPositionStart === null || formData.teamId === null || formData.gameId === null) {
       return null;
@@ -468,7 +471,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     updatedFormData.kickoff = formDisplay.kickoff;
     updatedFormData.punt = formDisplay.punt;
     updatedFormData.fieldGoal = formDisplay.fieldGoal;
-    updatedFormData.kickBlocked = formDisplay.kickBlock;
+    updatedFormData.kickBlocked = formDisplay.kickBlocked;
     updatedFormData.kickFake = formDisplay.fakeToPass || formDisplay.fakeToRush;
     // Play can only contain one of kickoff, punt, or field goal
     if ((updatedFormData.kickoff && (updatedFormData.punt || updatedFormData.fieldGoal)) || (updatedFormData.punt && updatedFormData.fieldGoal)) {
@@ -478,17 +481,17 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
       updatedFormData.kickerId = null;
       updatedFormData.kickReturnerId = null;
       updatedFormData.kickFieldedAt = null;
-      updatedFormData.kickFairCatch = null;
-      updatedFormData.kickGood = null;
-      updatedFormData.kickTouchback = null;
-      updatedFormData.kickFake = null;
+      updatedFormData.kickFairCatch = false;
+      updatedFormData.kickGood = false;
+      updatedFormData.kickTouchback = false;
+      updatedFormData.kickFake = false;
       updatedFormData.kickBlocked = false;
       updatedFormData.kickBlockedById = null;
-      updatedFormData.kickBlockRecoveredById = false;
-      updatedFormData.kickBlockRecoveredAt = false;
+      updatedFormData.kickBlockRecoveredById = null;
+      updatedFormData.kickBlockRecoveredAt = null;
     }
     if (!updatedFormData.fieldGoal) {
-      updatedFormData.kickGood = null;
+      updatedFormData.kickGood = false;
     }
     if (!updatedFormData.fieldGoal && !updatedFormData.punt) {
       updatedFormData.kickBlocked = false;
@@ -497,13 +500,13 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     if (!updatedFormData.punt && !updatedFormData.kickoff) {
       updatedFormData.kickReturnerId = null;
       updatedFormData.kickFieldedAt = null;
-      updatedFormData.kickFairCatch = null;
-      updatedFormData.kickTouchback = null;
+      updatedFormData.kickFairCatch = false;
+      updatedFormData.kickTouchback = false;
     }
     if (!updatedFormData.kickBlocked) {
       updatedFormData.kickBlockedById = null;
-      updatedFormData.kickBlockRecoveredById = false;
-      updatedFormData.kickBlockRecoveredAt = false;
+      updatedFormData.kickBlockRecoveredById = null;
+      updatedFormData.kickBlockRecoveredAt = null;
     }
     if (updatedFormData.kickGood && (updatedFormData.kickBlocked || updatedFormData.kickFake)) {
       return null;
@@ -549,7 +552,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
 
     if (updatedFormData.passerId !== null) {
       // A complete pass must have a receiver, and cannot have interception data or pass defenders
-      if (updatedFormData.completion && (updatedFormData.receiverId === null || updatedFormData.interceptedById !== null || updatedFormData.interceptedAt !== null || updatedFormData.passDefenders.length !== 0)) {
+      if (updatedFormData.completion && (updatedFormData.receiverId === null || updatedFormData.interceptedById !== null || updatedFormData.interceptedAt !== null || updatedFormData.passDefenderIds.length !== 0)) {
         return null;
       }
     }
@@ -617,9 +620,14 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     if ((!updatedFormData.kickTouchback && playerWithBall.teamId === awayTeam.id && updatedFormData.fieldPositionEnd === 50) || (playerWithBall.teamId === homeTeam.id && updatedFormData.fieldPositionEnd === -50)) {
       updatedFormData.safety = true;
       updatedFormData.cedingPlayerId = playerWithBall.id;
+    } else {
+      updatedFormData.safety = false;
+      updatedFormData.cedingPlayerId = null;
     }
 
-    const possessionChains = parsePossessionChanges(updatedFormData);
+    const possessionChanges = parsePossessionChanges(updatedFormData);
+    const possessionChains = possessionChanges.filter((chain) => chain.length > 0 && playerById(chain[0].ballTo).teamId === updatedFormData.teamId);
+    possessionChanges.forEach((chain) => console.warn(playerById(chain[0].ballTo).teamId));
 
     if (!possessionChains || (possessionChains.length === 0 && !formData.penalties.some((p) => p.enforced))) {
       return null;
@@ -630,10 +638,8 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    const newFormData = validatedFormData();
-    console.warn(formData, newFormData);
-    if (newFormData) {
-      createPlay(newFormData).then(() => {
+    if (submitFormData) {
+      createPlay(submitFormData).then(() => {
         onUpdate();
         allReset();
         setNewPlay((prev) => !prev);
@@ -653,8 +659,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
 
   useEffect(() => {
     if (formData.teamId) {
-      const newFormData = validatedFormData();
-      console.warn(newFormData);
+      const newFormData = validateFormData();
       setSubmitFormData(newFormData);
       if (newFormData?.teamId) {
         const playerId = parsePlayerPossession(newFormData);
@@ -724,33 +729,31 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
           onChange={handleClockChange}
         />
         <input className="playform-timebox" name="clockStart-seconds" type="number" min={formData.clockStart === 0 ? 0 : -1} max={60} value={((formData.clockStart || 0) % 60).toString().padStart(2, '0')} onChange={handleClockChange} />
-        {/* {!formData.kickoff && ( */}
-        <select name="down" onChange={handleChange} value={formData.down} disabled={formDisplay.kickoff}>
-          <option value={0}>No Down</option>
-          <option value={1}>1st</option>
-          <option value={2}>2nd</option>
-          <option value={3}>3rd</option>
-          <option value={4}>4th</option>
-        </select>
-        {/* )} */}
-        {/* {!!formData.down && ( */}
-        <div className="playform-to-go"> & {Math.abs(formData.toGain) === 50 ? 'Goal' : (formData.toGain - formData.fieldPositionStart) * (formData.teamId === awayTeam.id ? -1 : 1)}</div>
-        {/* )} */}
-        {/* {formData.fieldPositionStart !== null && ( */}
-        <div className="playform-line-of-scrimmage">
-          {formData.kickoff && 'Ball'} on {fieldPositionToString(formData.fieldPositionStart)}
-        </div>
-        {/* )} */}
+        {!formDisplay.kickoff && (
+          <select name="down" onChange={handleChange} value={formData.down} disabled={formDisplay.kickoff}>
+            <option value={0}>No Down</option>
+            <option value={1}>1st</option>
+            <option value={2}>2nd</option>
+            <option value={3}>3rd</option>
+            <option value={4}>4th</option>
+          </select>
+        )}
+        {!!formData.down && !formDisplay.kickoff && <div className="playform-to-go">& {Math.abs(formData.toGain) === 50 ? 'Goal' : (formData.toGain - formData.fieldPositionStart) * (formData.teamId === awayTeam.id ? -1 : 1)}</div>}
+        {formData.fieldPositionStart !== null && (
+          <div className="playform-line-of-scrimmage">
+            {formData.kickoff && 'Ball'} on {fieldPositionToString(formData.fieldPositionStart)}
+          </div>
+        )}
       </div>
       <FieldPositionSlider name="fieldPositionStart" value={formData?.fieldPositionStart} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'home' : 'away'} clearOption={false} />
-      {/* {formData.down !== 0 && ( */}
-      <div>
+      {formData.down !== 0 && !formDisplay.kickoff && (
         <div>
-          <i>To Gain</i> {fieldPositionToString(formData.toGain)}
+          <div>
+            <i>To Gain</i> {fieldPositionToString(formData.toGain)}
+          </div>
+          <FieldPositionSlider name="toGain" value={formData?.toGain} onChange={handleChange} color="red" clearOption={false} />
         </div>
-        <FieldPositionSlider name="toGain" value={formData?.toGain} onChange={handleChange} color="red" clearOption={false} />
-      </div>
-      {/* )} */}
+      )}
       <div className="playform-type-radios">
         <label>
           <input type="radio" name="pass" readOnly value={!formDisplay.pass} checked={formDisplay.pass} onClick={handleDisplay} />
@@ -773,38 +776,192 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
           Kickoff
         </label>
       </div>
-      {/* {formDisplay.punt && ( */}
-      <div className="pf-punt">
-        <p>Kicker:</p>
-        <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
-        <label>
-          Fake:
-          <input
-            type="checkbox"
-            name="kickFake"
-            value={!formData.kickFake}
-            checked={formData.kickFake}
-            onChange={(e) => {
-              handleChange(e);
-              if (e.target.value === 'true') {
-                selectiveReset(['kickFieldedAt', 'kickReturnerId', 'kickFairCatch', 'kickTouchback']);
-              }
-              if (e.target.value === 'false') {
-                handleDisplay(e);
-              }
-            }}
-          />
-        </label>
-        {/* {!formData.kickFake && ( */}
-        <div>
+      {formDisplay.punt && (
+        <div className="pf-punt">
+          <p>Kicker:</p>
+          <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
+          <label>
+            Fake:
+            <input
+              type="checkbox"
+              name="kickFake"
+              value={!formData.kickFake}
+              checked={formData.kickFake}
+              onChange={(e) => {
+                handleChange(e);
+                if (e.target.value === 'true') {
+                  selectiveReset(['kickFieldedAt', 'kickReturnerId', 'kickFairCatch', 'kickTouchback']);
+                }
+                if (e.target.value === 'false') {
+                  handleDisplay(e);
+                }
+              }}
+            />
+          </label>
+          {!formData.kickFake && (
+            <div>
+              <p>Returner:</p>
+              <PlayerSelect name="kickReturnerId" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.kickReturnerId || 'null'} />
+            </div>
+          )}
+          {!formData.kickFake && (
+            <div>
+              <label>
+                <p>Touchback</p>
+                <input
+                  type="checkbox"
+                  name="kickTouchback"
+                  value={!formData.kickTouchback}
+                  checked={formData.kickTouchback}
+                  onChange={(e) => {
+                    handleChange(e);
+                    selectiveReset(['kickFieldedAt']);
+                  }}
+                />
+              </label>
+              <label>
+                Fair Catch
+                <input
+                  type="checkbox"
+                  name="kickFairCatch"
+                  value={!formData.kickFairCatch}
+                  checked={formData.kickFairCatch}
+                  onChange={(e) => {
+                    handleChange(e);
+                    selectiveReset(['kickFieldedAt']);
+                  }}
+                />
+              </label>
+            </div>
+          )}
+          {!formData.kickFake && <FieldPositionSlider name="kickFieldedAt" value={formData?.kickFieldedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />}
+        </div>
+      )}
+      {formDisplay.fieldGoal && (
+        <div className="pf-fieldgoal">
+          <p>Kicker:</p>
+          <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
+          <label>
+            <p>Fake</p>
+            <input
+              type="checkbox"
+              name="kickFake"
+              value={!formData.kickFake}
+              checked={formData.kickFake}
+              onChange={(e) => {
+                handleChange(e);
+                if (e.target.value === 'true') {
+                  selectiveReset(['kickGood']);
+                }
+                if (e.target.value === 'false') {
+                  handleDisplay(e);
+                }
+              }}
+            />
+          </label>
+          {!formData.kickFake && (
+            <label>
+              <p>Good</p>
+              <input type="checkbox" name="kickGood" value={!formData.kickGood} checked={formData.kickGood} onChange={handleChange} />
+            </label>
+          )}
+        </div>
+      )}
+      {(formDisplay.fieldGoal || formDisplay.punt) && !formData.kickFake && (
+        <div className="pf-kickblock">
+          <label>
+            <p>Blocked</p>
+            <input type="checkbox" name="kickBlocked" value={!formDisplay.kickBlocked} checked={formDisplay.kickBlocked} onChange={handleDisplay} />
+          </label>
+          {formDisplay.kickBlocked && (
+            <>
+              <div>
+                <p>Blocked by</p>
+                <PlayerSelect name="kickBlockedById" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.kickBlockedById || 'null'} />
+                <p>Recovered by</p>
+                <PlayerSelect name="kickBlockRecoveredById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleChange} value={formData.kickBlockRecoveredById || 'null'} />
+                <div>at {fieldPositionToString(formData.kickBlockRecoveredAt)}</div>
+              </div>
+              <FieldPositionSlider name="kickBlockRecoveredAt" value={formData?.kickBlockRecoveredAt} onChange={handleChange} possession={playerById(formData.kickBlockRecoveredById)?.teamId === homeTeam.id ? 'home' : 'away'} />
+            </>
+          )}
+        </div>
+      )}
+      {formData.kickFake && (
+        <div className="pf-fake-play-toggles">
+          <label>
+            <input type="radio" name="fakeToPass" readOnly value={!formDisplay.fakeToPass} checked={formDisplay.fakeToPass} onClick={handleDisplay} />
+            Pass
+          </label>
+          <label>
+            <input type="radio" name="fakeToRush" readOnly value={!formDisplay.fakeToRush} checked={formDisplay.fakeToRush} onClick={handleDisplay} />
+            Rush
+          </label>
+        </div>
+      )}
+      {(formDisplay.pass || formDisplay.fakeToPass) && (
+        <div className="pf-pass">
+          <div className="pf-pass-root">
+            <p>Passer:</p>
+            <PlayerSelect name="passerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.passerId || 'null'} />
+            <p>Receiver:</p>
+            <PlayerSelect name="receiverId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.receiverId || 'null'} />
+            <label>
+              Complete:
+              <input
+                type="checkbox"
+                name="completion"
+                value={!formData.completion}
+                checked={formData.completion}
+                onChange={(e) => {
+                  handleChange(e);
+                  selectiveReset(['interceptedById', 'interceptedAt']);
+                  handleDisplay({ target: { name: 'interception', value: 'false' } });
+                }}
+              />
+            </label>
+            <label>
+              Interception:
+              <input
+                type="checkbox"
+                name="interception"
+                value={!formDisplay.interception}
+                checked={formDisplay?.interception}
+                onChange={(e) => {
+                  handleDisplay(e);
+                  selectiveReset(['completion']);
+                }}
+              />
+            </label>
+          </div>
+          <p>Pass Defenders</p>
+          <PlayerMultiSelect name="passDefenderIds" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.passDefenderIds} />
+          {formDisplay?.interception && (
+            <div className="playform-interception">
+              <div className="pf-int-statline">
+                <p>Intercepted by</p>
+                <PlayerSelect name="interceptedById" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.interceptedById || 'null'} />
+                <div>at {fieldPositionToString(formData.interceptedAt)}</div>
+              </div>
+              <FieldPositionSlider name="interceptedAt" value={formData?.interceptedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />
+            </div>
+          )}
+        </div>
+      )}
+      {(formDisplay.rush || formDisplay.fakeToRush) && (
+        <div className="pf-rush">
+          <p>Rusher:</p>
+          <PlayerSelect name="rusherId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.rusherId || 'null'} />
+        </div>
+      )}
+      {formDisplay.kickoff && (
+        <div className="pf-kickoff">
+          <p>Kicker:</p>
+          <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
           <p>Returner:</p>
           <PlayerSelect name="kickReturnerId" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.kickReturnerId || 'null'} />
-        </div>
-        {/* )} */}
-        {/* {!formData.kickFake && ( */}
-        <div>
           <label>
-            <p>Touchback</p>
+            Touchback:
             <input
               type="checkbox"
               name="kickTouchback"
@@ -812,185 +969,40 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
               checked={formData.kickTouchback}
               onChange={(e) => {
                 handleChange(e);
-                selectiveReset(['kickFieldedAt']);
+                handleChange({ target: { name: 'kickFieldedAt', value: 'null' } });
               }}
             />
           </label>
-          <label>
-            Fair Catch
-            <input
-              type="checkbox"
-              name="kickFairCatch"
-              value={!formData.kickFairCatch}
-              checked={formData.kickFairCatch}
-              onChange={(e) => {
-                handleChange(e);
-                selectiveReset(['kickFieldedAt']);
-              }}
-            />
-          </label>
-        </div>
-        {/* )} */}
-        {/* {!formData.kickFake && ( */}
-        <FieldPositionSlider name="kickFieldedAt" value={formData?.kickFieldedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />
-        {/* )} */}
-      </div>
-      {/* )} */}
-      {/* {formDisplay.fieldGoal && ( */}
-      <div className="pf-fieldgoal">
-        <p>Kicker:</p>
-        <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
-        <label>
-          <p>Fake</p>
-          <input
-            type="checkbox"
-            name="kickFake"
-            value={!formData.kickFake}
-            checked={formData.kickFake}
-            onChange={(e) => {
-              handleChange(e);
-              if (e.target.value === 'true') {
-                selectiveReset(['kickGood']);
-              }
-              if (e.target.value === 'false') {
-                handleDisplay(e);
-              }
-            }}
-          />
-        </label>
-        {/* {!formData.kickFake && ( */}
-        <label>
-          <p>Good</p>
-          <input type="checkbox" name="kickGood" value={!formData.kickGood} checked={formData.kickGood} onChange={handleChange} />
-        </label>
-        {/* )} */}
-      </div>
-      {/* )} */}
-      <div className="pf-kickblock">
-        <label>
-          <p>Blocked</p>
-          <input type="checkbox" name="kickBlocked" value={!formData.kickBlocked} checked={formData.kickBlocked} onChange={handleChange} />
-        </label>
-        <div>
-          <p>Blocked by</p>
-          <PlayerSelect name="kickBlockedById" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.kickBlockedById || 'null'} />
-          <p>Recovered by</p>
-          <PlayerSelect name="kickBlockRecoveredById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleChange} value={formData.kickBlockRecoveredById || 'null'} />
-          <div>at {fieldPositionToString(formData.kickBlockRecoveredAt)}</div>
-        </div>
-        <FieldPositionSlider name="kickBlockRecoveredAt" value={formData?.kickBlockRecoveredAt} onChange={handleChange} possession={playerById(formData.kickBlockRecoveredById)?.teamId === homeTeam.id ? 'home' : 'away'} />
-      </div>
-      {/* {formData.kickFake && ( */}
-      <div className="pf-fake-play-toggles">
-        <label>
-          <input type="radio" name="fakeToPass" readOnly value={!formDisplay.fakeToPass} checked={formDisplay.fakeToPass} onClick={handleDisplay} />
-          Pass
-        </label>
-        <label>
-          <input type="radio" name="fakeToRush" readOnly value={!formDisplay.fakeToRush} checked={formDisplay.fakeToRush} onClick={handleDisplay} />
-          Rush
-        </label>
-      </div>
-      {/* )} */}
-      {/* {(formDisplay.pass || formDisplay.fakeToPass) && ( */}
-      <div className="pf-pass">
-        <div className="pf-pass-root">
-          <p>Passer:</p>
-          <PlayerSelect name="passerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.passerId || 'null'} />
-          <p>Receiver:</p>
-          <PlayerSelect name="receiverId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.receiverId || 'null'} />
-          <label>
-            Complete:
-            <input
-              type="checkbox"
-              name="completion"
-              value={!formData.completion}
-              checked={formData.completion}
-              onChange={(e) => {
-                handleChange(e);
-                selectiveReset(['interceptedById', 'interceptedAt']);
-                handleDisplay({ target: { name: 'interception', value: 'false' } });
-              }}
-            />
-          </label>
-          <label>
-            Interception:
-            <input
-              type="checkbox"
-              name="interception"
-              value={!formDisplay.interception}
-              checked={formDisplay?.interception}
-              onChange={(e) => {
-                handleDisplay(e);
-                selectiveReset(['completion']);
-              }}
-            />
-          </label>
-        </div>
-        <p>Pass Defenders</p>
-        <PlayerMultiSelect name="passDefenderIds" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.passDefenderIds} />
-        {/* {formDisplay?.interception && ( */}
-        <div className="playform-interception">
-          <div className="pf-int-statline">
-            <p>Intercepted by</p>
-            <PlayerSelect name="interceptedById" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.interceptedById || 'null'} />
-            <div>at {fieldPositionToString(formData.interceptedAt)}</div>
-          </div>
-          <FieldPositionSlider name="interceptedAt" value={formData?.interceptedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />
-        </div>
-        {/* )} */}
-      </div>
-      {/* )} */}
-      {/* {(formDisplay.rush || formDisplay.fakeToRush) && ( */}
-      <div className="pf-rush">
-        <p>Rusher:</p>
-        <PlayerSelect name="rusherId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.rusherId || 'null'} />
-      </div>
-      {/* )} */}
-      {/* {formDisplay.kickoff && ( */}
-      <div className="pf-kickoff">
-        <p>Kicker:</p>
-        <PlayerSelect name="kickerId" players={(formData.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.kickerId || 'null'} />
-        <p>Returner:</p>
-        <PlayerSelect name="kickReturnerId" players={(formData.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.kickReturnerId || 'null'} />
-        <label>
-          Touchback:
-          <input
-            type="checkbox"
-            name="kickTouchback"
-            value={!formData.kickTouchback}
-            checked={formData.kickTouchback}
-            onChange={(e) => {
-              handleChange(e);
-              handleChange({ target: { name: 'kickFieldedAt', value: 'null' } });
-            }}
-          />
-        </label>
-        {/* {!formData.kickTouchback && ( */}
-        <div>
+          {/* {!formData.kickTouchback && ( */}
           <div>
-            <i>Fielded at</i> {fieldPositionToString(formData.kickFieldedAt)}
+            <div>
+              <i>Fielded at</i> {fieldPositionToString(formData.kickFieldedAt)}
+            </div>
+            <FieldPositionSlider name="kickFieldedAt" value={formData?.kickFieldedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />
           </div>
-          <FieldPositionSlider name="kickFieldedAt" value={formData?.kickFieldedAt} onChange={handleChange} possession={formData.teamId === homeTeam.id ? 'away' : 'home'} />
+          {/* )} */}
         </div>
-        {/* )} */}
-      </div>
-      {/* )} */}
+      )}
       <div className="pf-laterals">
         <p>Laterals</p>
-        <div>
-          <p>From</p>
-          <PlayerSelect name="prevCarrierId" players={[...(playerById(lateralCreator.newCarrierId)?.teamId === awayTeam.id ? [] : homeTeam.players.filter((p) => p.id !== lateralCreator.newCarrierId)), ...(playerById(lateralCreator.newCarrierId)?.teamId === homeTeam.id ? [] : awayTeam.players.filter((p) => p.id !== lateralCreator.newCarrierId))]} onChange={handleLateralChange} value={lateralCreator.prevCarrierId || 'null'} />
-          <p>to</p>
-          <PlayerSelect name="newCarrierId" players={[...(playerById(lateralCreator.prevCarrierId)?.teamId === awayTeam.id ? [] : homeTeam.players.filter((p) => p.id !== lateralCreator.prevCarrierId)), ...(playerById(lateralCreator.prevCarrierId)?.teamId === homeTeam.id ? [] : awayTeam.players.filter((p) => p.id !== lateralCreator.prevCarrierId))]} onChange={handleLateralChange} value={lateralCreator.newCarrierId || 'null'} />
-          <p>at {fieldPositionToString(lateralCreator.possessionAt)}</p>
-          <FieldPositionSlider name="possessionAt" value={lateralCreator?.possessionAt} onChange={handleLateralChange} possession={lateralCreator.newCarrierId && (playerById(lateralCreator.newCarrierId).teamId === homeTeam.id ? 'home' : 'away')} />
-          <p>Advanced to {fieldPositionToString(fumbleCreator.fumbleRecoveredAt)}</p>
-          <FieldPositionSlider name="carriedTo" value={lateralCreator?.carriedTo} onChange={handleLateralChange} possession={lateralCreator.newCarrierId && (playerById(lateralCreator.newCarrierId).teamId === homeTeam.id ? 'home' : 'away')} />
-          <button type="button" onClick={handleLateralAdd}>
-            Add
-          </button>
-        </div>
+        <button type="button" name="lateralCreator" value={!formDisplay.lateralCreator} onClick={handleDisplay}>
+          {formDisplay.lateralCreator ? '-' : '+'}
+        </button>
+        {formDisplay.lateralCreator && (
+          <div>
+            <p>From</p>
+            <PlayerSelect name="prevCarrierId" players={[...(playerById(lateralCreator.newCarrierId)?.teamId === awayTeam.id ? [] : homeTeam.players.filter((p) => p.id !== lateralCreator.newCarrierId)), ...(playerById(lateralCreator.newCarrierId)?.teamId === homeTeam.id ? [] : awayTeam.players.filter((p) => p.id !== lateralCreator.newCarrierId))]} onChange={handleLateralChange} value={lateralCreator.prevCarrierId || 'null'} />
+            <p>to</p>
+            <PlayerSelect name="newCarrierId" players={[...(playerById(lateralCreator.prevCarrierId)?.teamId === awayTeam.id ? [] : homeTeam.players.filter((p) => p.id !== lateralCreator.prevCarrierId)), ...(playerById(lateralCreator.prevCarrierId)?.teamId === homeTeam.id ? [] : awayTeam.players.filter((p) => p.id !== lateralCreator.prevCarrierId))]} onChange={handleLateralChange} value={lateralCreator.newCarrierId || 'null'} />
+            <p>at {fieldPositionToString(lateralCreator.possessionAt)}</p>
+            <FieldPositionSlider name="possessionAt" value={lateralCreator?.possessionAt} onChange={handleLateralChange} possession={lateralCreator.newCarrierId && (playerById(lateralCreator.newCarrierId).teamId === homeTeam.id ? 'home' : 'away')} />
+            <p>Advanced to {fieldPositionToString(lateralCreator.carriedTo)}</p>
+            <FieldPositionSlider name="carriedTo" value={lateralCreator?.carriedTo} onChange={handleLateralChange} possession={lateralCreator.newCarrierId && (playerById(lateralCreator.newCarrierId).teamId === homeTeam.id ? 'home' : 'away')} />
+            <button type="button" onClick={handleLateralAdd}>
+              Add
+            </button>
+          </div>
+        )}
         <div>
           {formData.laterals.map((l) => {
             const prevCarrier = playerById(l.prevCarrierId);
@@ -1011,21 +1023,26 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
       </div>
       <div className="pf-fumbles">
         <p>Fumbles</p>
-        <div>
-          <p>Committed by</p>
-          <PlayerSelect name="fumbleCommittedById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleCommittedById || 'null'} />
-          <p>Forced by</p>
-          <PlayerSelect name="fumbleForcedById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleForcedById || 'null'} />
-          <p>at {fieldPositionToString(fumbleCreator.fumbledAt)}</p>
-          <FieldPositionSlider name="fumbledAt" value={fumbleCreator?.fumbledAt} onChange={handleFumbleChange} possession={fumbleCreator.fumbleCommittedById && (playerById(fumbleCreator.fumbleCommittedById).teamId === homeTeam.id ? 'home' : 'away')} />
-          <p>Recovered by</p>
-          <PlayerSelect name="fumbleRecoveredById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleRecoveredById || 'null'} />
-          <p>at {fieldPositionToString(fumbleCreator.fumbleRecoveredAt)}</p>
-          <FieldPositionSlider name="fumbleRecoveredAt" value={fumbleCreator?.fumbleRecoveredAt} onChange={handleFumbleChange} possession={fumbleCreator.fumbleRecoveredById && (playerById(fumbleCreator.fumbleRecoveredById).teamId === homeTeam.id ? 'home' : 'away')} />
-          <button type="button" onClick={handleFumbleAdd}>
-            Add
-          </button>
-        </div>
+        <button type="button" name="fumbleCreator" value={!formDisplay.fumbleCreator} onClick={handleDisplay}>
+          {formDisplay.fumbleCreator ? '-' : '+'}
+        </button>
+        {formDisplay.fumbleCreator && (
+          <div>
+            <p>Committed by</p>
+            <PlayerSelect name="fumbleCommittedById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleCommittedById || 'null'} />
+            <p>Forced by</p>
+            <PlayerSelect name="fumbleForcedById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleForcedById || 'null'} />
+            <p>at {fieldPositionToString(fumbleCreator.fumbledAt)}</p>
+            <FieldPositionSlider name="fumbledAt" value={fumbleCreator?.fumbledAt} onChange={handleFumbleChange} possession={fumbleCreator.fumbleCommittedById && (playerById(fumbleCreator.fumbleCommittedById).teamId === homeTeam.id ? 'home' : 'away')} />
+            <p>Recovered by</p>
+            <PlayerSelect name="fumbleRecoveredById" players={[...homeTeam.players, ...awayTeam.players]} onChange={handleFumbleChange} value={fumbleCreator.fumbleRecoveredById || 'null'} />
+            <p>at {fieldPositionToString(fumbleCreator.fumbleRecoveredAt)}</p>
+            <FieldPositionSlider name="fumbleRecoveredAt" value={fumbleCreator?.fumbleRecoveredAt} onChange={handleFumbleChange} possession={fumbleCreator.fumbleRecoveredById && (playerById(fumbleCreator.fumbleRecoveredById).teamId === homeTeam.id ? 'home' : 'away')} />
+            <button type="button" onClick={handleFumbleAdd}>
+              Add
+            </button>
+          </div>
+        )}
         <div>
           {formData.fumbles.map((f) => {
             const committedBy = playerById(f.fumbleCommittedById);
@@ -1069,62 +1086,73 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
         onChange={handleClockChange}
       />
       <input className="playform-timebox" name="clockEnd-seconds" type="number" min={!formData.clockEnd ? 0 : -1} max={formData.clockEnd < formData.clockStart ? 60 : (formData.clockStart || 0) % 60} value={formData.clockEnd === null ? '' : ((formData.clockEnd || 0) % 60).toString().padStart(2, '0')} onChange={handleClockChange} />
-      {/* {!formData.kickGood && ( */}
-      <div>
+      {!formDisplay.fieldGoal || (formDisplay.fieldGoal && !formData.kickGood) ? (
         <div>
-          <i>Ending Field Position</i> {fieldPositionToString(formData.fieldPositionEnd)}
+          <div>
+            <i>Ending Field Position</i> {fieldPositionToString(formData.fieldPositionEnd)}
+          </div>
+          <FieldPositionSlider name="fieldPositionEnd" value={formData?.fieldPositionEnd} onChange={handleChange} possession={playerWithBall.teamId && (playerWithBall.teamId === homeTeam.id ? 'home' : 'away')} />
         </div>
-        <FieldPositionSlider name="fieldPositionEnd" value={formData?.fieldPositionEnd} onChange={handleChange} possession={playerWithBall.teamId && (playerWithBall.teamId === homeTeam.id ? 'home' : 'away')} />
-      </div>
-      {/* )} */}
+      ) : (
+        <div>
+          <p>
+            {formData.teamId === homeTeam.id ? homeTeam.locationName : awayTeam.locationName} {Math.abs(formData.fieldPositionStart + 50 * (formData.teamId === homeTeam.id ? -1 : 1)) + 17}-yard Field Goal Good!
+          </p>
+        </div>
+      )}
       <div className="pf-play-penalties">
         <p>Penalties</p>
-        <div>
-          <select className="penalty-select" name="penaltyId" onChange={handlePlayPenaltyChange} value={penaltyCreator.penaltyId || 1}>
-            {penalties.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name}
-              </option>
-            ))}
-          </select>
+        <button type="button" name="penaltyCreator" value={!formDisplay.penaltyCreator} onClick={handleDisplay}>
+          {formDisplay.penaltyCreator ? '-' : '+'}
+        </button>
+        {formDisplay.penaltyCreator && (
           <div>
+            <select className="penalty-select" name="penaltyId" onChange={handlePlayPenaltyChange} value={penaltyCreator.penaltyId || 1}>
+              {penalties.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+            <div>
+              <label>
+                <input type="radio" name="teamId-penalty" value={homeTeam.id} checked={penaltyCreator.teamId === homeTeam.id} readOnly onClick={handlePlayPenaltyChange} />
+                {homeTeam.locationName}
+              </label>
+              <label>
+                {awayTeam.locationName}
+                <input type="radio" name="teamId-penalty" value={awayTeam.id} checked={penaltyCreator.teamId === awayTeam.id} onChange={handlePlayPenaltyChange} />
+              </label>
+            </div>
+            <p>Penalized Player</p>
+            <PlayerSelect name="playerId" players={[...(penaltyCreator.teamId !== homeTeam.id ? awayTeam.players : []), ...(penaltyCreator.teamId !== awayTeam.id ? homeTeam.players : [])]} onChange={handlePlayPenaltyChange} value={penaltyCreator.playerId || 'null'} />
             <label>
-              <input type="radio" name="teamId-penalty" value={homeTeam.id} checked={penaltyCreator.teamId === homeTeam.id} readOnly onClick={handlePlayPenaltyChange} />
-              {homeTeam.locationName}
+              Enforced:
+              <input type="checkbox" name="enforced" value={!penaltyCreator.enforced} checked={penaltyCreator.enforced} onChange={handlePlayPenaltyChange} />
+            </label>
+            <p>Enforced at {fieldPositionToString(penaltyCreator.enforcedFrom)}</p>
+            <FieldPositionSlider name="enforcedFrom" value={penaltyCreator?.enforcedFrom} onChange={handlePlayPenaltyChange} possession={penaltyCreator.teamId !== null && (penaltyCreator.teamId === homeTeam.id ? 'away' : 'home')} />
+            <label>
+              <p>Yardage</p>
+              <input type="number" name="yardage" min={0} max={100} value={penaltyCreator.yardage || 0} onChange={handlePlayPenaltyChange} />
             </label>
             <label>
-              {awayTeam.locationName}
-              <input type="radio" name="teamId-penalty" value={awayTeam.id} checked={penaltyCreator.teamId === awayTeam.id} onChange={handlePlayPenaltyChange} />
+              No Play:
+              <input type="checkbox" name="noPlay" value={!penaltyCreator.noPlay} checked={penaltyCreator.noPlay} onChange={handlePlayPenaltyChange} />
             </label>
+            <label>
+              Loss Of Down:
+              <input type="checkbox" name="lossOfDown" value={!penaltyCreator.lossOfDown} checked={penaltyCreator.lossOfDown} onChange={handlePlayPenaltyChange} />
+            </label>
+            <label>
+              Automatic First Down:
+              <input type="checkbox" name="autoFirstDown" value={!penaltyCreator.autoFirstDown} checked={penaltyCreator.autoFirstDown} onChange={handlePlayPenaltyChange} />
+            </label>
+            <button type="button" onClick={handlePlayPenaltyAdd}>
+              Add
+            </button>
           </div>
-          <p>Penalized Player</p>
-          <PlayerSelect name="playerId" players={[...(penaltyCreator.teamId !== homeTeam.id ? awayTeam.players : []), ...(penaltyCreator.teamId !== awayTeam.id ? homeTeam.players : [])]} onChange={handlePlayPenaltyChange} value={penaltyCreator.playerId || 'null'} />
-          <label>
-            Enforced:
-            <input type="checkbox" name="enforced" value={!penaltyCreator.enforced} checked={penaltyCreator.enforced} onChange={handlePlayPenaltyChange} />
-          </label>
-          <p>Enforced at {fieldPositionToString(penaltyCreator.enforcedFrom)}</p>
-          <FieldPositionSlider name="enforcedFrom" value={penaltyCreator?.enforcedFrom} onChange={handlePlayPenaltyChange} possession={penaltyCreator.teamId !== null && (penaltyCreator.teamId === homeTeam.id ? 'away' : 'home')} />
-          <label>
-            <p>Yardage</p>
-            <input type="number" name="yardage" min={0} max={100} value={penaltyCreator.yardage || 0} onChange={handlePlayPenaltyChange} />
-          </label>
-          <label>
-            No Play:
-            <input type="checkbox" name="noPlay" value={!penaltyCreator.noPlay} checked={penaltyCreator.noPlay} onChange={handlePlayPenaltyChange} />
-          </label>
-          <label>
-            Loss Of Down:
-            <input type="checkbox" name="lossOfDown" value={!penaltyCreator.lossOfDown} checked={penaltyCreator.lossOfDown} onChange={handlePlayPenaltyChange} />
-          </label>
-          <label>
-            Automatic First Down:
-            <input type="checkbox" name="autoFirstDown" value={!penaltyCreator.autoFirstDown} checked={penaltyCreator.autoFirstDown} onChange={handlePlayPenaltyChange} />
-          </label>
-          <button type="button" onClick={handlePlayPenaltyAdd}>
-            Add
-          </button>
-        </div>
+        )}
         <div>
           {formData.penalties.map((pp) => {
             const player = playerById(pp.playerId);
@@ -1137,10 +1165,6 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
                   {playPenaltyName}, {teamName}
                   {player.id ? ` (${player.lastName}, ${player?.firstName[0]}. #${player.jerseyNumber})` : ''}.{pp.enforced ? ` Enforced ${pp.yardage} yard${Math.abs(pp.yardage) !== 1 && 's'} from ${fieldPositionToString(pp.enforcedFrom)}.${pp.noPlay ? ' No Play.' : ''}${pp.lossOfDown ? ' Loss of Down.' : ''}${pp.autoFirstDown ? ' Automatic First Down.' : ''}` : ' Declined.'}
                 </p>
-                {/* <p>
-                  {prevCarrier.lastName}, {prevCarrier?.firstName[0]}. #{prevCarrier.jerseyNumber} lateral to {newCarrier.lastName}, {newCarrier?.firstName[0]}. #{newCarrier.jerseyNumber}
-                  {l.possessionAt !== null ? ` at ${fieldPositionToString(l.possessionAt)}` : ''}.{l.carriedTo !== null && l.possessionAt != null && ` Advanced ${(l.carriedTo - l.possessionAt) * (newCarrier.teamId === homeTeam.id ? 1 : -1)} yard${Math.abs(l.carriedTo - l.possessionAt) !== 1 && 's'} to ${fieldPositionToString(l.carriedTo)}.`}
-                </p> */}
                 <button type="button" onClick={() => handlePlayPenaltyRemove(pp.id)}>
                   X
                 </button>
@@ -1149,102 +1173,116 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
           })}
         </div>
       </div>
-      {/* {!formData.fieldGoal && */}
       {((playerWithBall.teamId === homeTeam.id && formData.fieldPositionEnd === 50) || (playerWithBall.teamId === awayTeam.id && formData.fieldPositionEnd === -50)) && (
-        // (
-        <p>Touchdown {playerWithBall.teamId === homeTeam.id ? `${homeTeam.locationName} ${homeTeam.nickname}` : `${awayTeam.locationName} ${awayTeam.nickname}`}!</p>
+        <>
+          <p>Touchdown {playerWithBall.teamId === homeTeam.id ? `${homeTeam.locationName} ${homeTeam.nickname}` : `${awayTeam.locationName} ${awayTeam.nickname}`}!</p>
+          <div>
+            <div className="pf-touchdown-toggles">
+              <label>
+                <input
+                  type="radio"
+                  name="extraPoint"
+                  readOnly
+                  value={!formData.extraPoint}
+                  checked={formData.extraPoint}
+                  onClick={(e) => {
+                    if (e.target.value === 'true') {
+                      selectiveReset(['conversion', 'conversionPasserId', 'conversionReceiverId', 'conversionRusherId', 'defensiveConversion', 'conversionReturnerId']);
+                    } else {
+                      selectiveReset(['extraPoint', 'extraPointGood', 'extraPointFake', 'defensiveConversion', 'extraPointKickerId']);
+                    }
+                    handleChange(e);
+                  }}
+                />
+                Extra Point
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="conversion"
+                  readOnly
+                  value={!formData.conversion}
+                  checked={formData.conversion}
+                  onClick={(e) => {
+                    if (e.target.value === 'true') {
+                      selectiveReset(['extraPoint', 'extraPointGood', 'extraPointFake', 'defensiveConversion', 'extraPointKickerId']);
+                    } else {
+                      selectiveReset(['conversion', 'conversionPasserId', 'conversionReceiverId', 'conversionRusherId', 'defensiveConversion', 'conversionReturnerId']);
+                    }
+                    handleChange(e);
+                  }}
+                />
+                2pt Conversion
+              </label>
+            </div>
+            {formData.extraPoint && (
+              <div>
+                <p>Kicker:</p>
+                <PlayerSelect name="extraPointKickerId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.extraPointKickerId || 'null'} />
+                <label>
+                  Extra Point Good:
+                  <input type="checkbox" name="extraPointGood" value={!formData.extraPointGood} checked={formData.extraPointGood} onChange={handleChange} />
+                </label>
+                {!formData.extraPointGood && (
+                  <label>
+                    Fake:
+                    <input type="checkbox" name="extraPointFake" value={!formData.extraPointFake} checked={formData.extraPointFake} onChange={handleChange} />
+                  </label>
+                )}
+              </div>
+            )}
+            {(formData.conversion || formData.extraPointFake) && (
+              <>
+                <div className="pf-two-point-toggles">
+                  <label>
+                    <input type="radio" name="twoPointPass" readOnly value={!formDisplay.twoPointPass} checked={formDisplay.twoPointPass} onClick={handleDisplay} />
+                    Pass
+                  </label>
+                  <label>
+                    <input type="radio" name="twoPointRush" readOnly value={!formDisplay.twoPointRush} checked={formDisplay.twoPointRush} onClick={handleDisplay} />
+                    Rush
+                  </label>
+                </div>
+                <div>
+                  {formDisplay.twoPointPass && (
+                    <>
+                      <p>Passer:</p>
+                      <PlayerSelect name="conversionPasserId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionPasserId || 'null'} />
+                      <p>Receiver:</p>
+                      <PlayerSelect name="conversionReceiverId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionReceiverId || 'null'} />
+                    </>
+                  )}
+                  {formDisplay.twoPointRush && (
+                    <>
+                      <p>Rusher:</p>
+                      <PlayerSelect name="conversionRusherId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionRusherId || 'null'} />
+                    </>
+                  )}
+                  <label>
+                    Conversion Good:
+                    <input type="checkbox" name="conversionGood" value={!formData.conversionGood} checked={formData.conversionGood} onChange={handleChange} />
+                  </label>
+                </div>
+              </>
+            )}
+          </div>
+          {(formData.extraPoint || formData.conversion) && !formData.conversionGood && (
+            <div>
+              <label>
+                Defensive Conversion:
+                <input type="checkbox" name="defensiveConversion" value={!formData.defensiveConversion} checked={formData.defensiveConversion} onChange={handleChange} />
+              </label>
+              {formData.defensiveConversion && (
+                <>
+                  <p>Returned by</p>
+                  <PlayerSelect name="conversionReturnerId" players={(playerWithBall.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.conversionReturnerId || 'null'} />
+                </>
+              )}
+            </div>
+          )}
+        </>
       )}
-      {((playerWithBall.teamId === homeTeam.id && formData.fieldPositionEnd === -50) || (playerWithBall.teamId === awayTeam.id && formData.fieldPositionEnd === 50)) && (
-        // (
-        <p>Safety {playerWithBall.teamId === homeTeam.id ? `${awayTeam.locationName} ${awayTeam.nickname}` : `${homeTeam.locationName} ${homeTeam.nickname}`}!</p>
-      )}
-      <div>
-        <div className="pf-touchdown-toggles">
-          <label>
-            <input
-              type="radio"
-              name="extraPoint"
-              readOnly
-              value={!formData.extraPoint}
-              checked={formData.extraPoint}
-              onClick={(e) => {
-                if (e.target.value === 'true') {
-                  selectiveReset(['conversion', 'conversionPasserId', 'conversionReceiverId', 'conversionRusherId', 'defensiveConversion', 'conversionReturnerId']);
-                } else {
-                  selectiveReset(['extraPoint', 'extraPointGood', 'extraPointFake', 'defensiveConversion', 'extraPointKickerId']);
-                }
-                handleChange(e);
-              }}
-            />
-            Extra Point
-          </label>
-          <label>
-            <input
-              type="radio"
-              name="conversion"
-              readOnly
-              value={!formData.conversion}
-              checked={formData.conversion}
-              onClick={(e) => {
-                if (e.target.value === 'true') {
-                  selectiveReset(['extraPoint', 'extraPointGood', 'extraPointFake', 'defensiveConversion', 'extraPointKickerId']);
-                } else {
-                  selectiveReset(['conversion', 'conversionPasserId', 'conversionReceiverId', 'conversionRusherId', 'defensiveConversion', 'conversionReturnerId']);
-                }
-                handleChange(e);
-              }}
-            />
-            2pt Conversion
-          </label>
-        </div>
-        <div>
-          <p>Kicker:</p>
-          <PlayerSelect name="extraPointKickerId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.extraPointKickerId || 'null'} />
-          <label>
-            Extra Point Good:
-            <input type="checkbox" name="extraPointGood" value={!formData.extraPointGood} checked={formData.extraPointGood} onChange={handleChange} />
-          </label>
-          <label>
-            Fake:
-            <input type="checkbox" name="extraPointFake" value={!formData.extraPointFake} checked={formData.extraPointFake} onChange={handleChange} />
-          </label>
-        </div>
-        {/* {(formData.conversion || formData.extraPointFake) && ( */}
-        <div className="pf-two-point-toggles">
-          <label>
-            <input type="radio" name="twoPointPass" readOnly value={!formDisplay.twoPointPass} checked={formDisplay.twoPointPass} onClick={handleDisplay} />
-            Pass
-          </label>
-          <label>
-            <input type="radio" name="twoPointRush" readOnly value={!formDisplay.twoPointRush} checked={formDisplay.twoPointRush} onClick={handleDisplay} />
-            Rush
-          </label>
-        </div>
-        <div>
-          <p>Passer:</p>
-          <PlayerSelect name="conversionPasserId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionPasserId || 'null'} />
-          <p>Receiver:</p>
-          <PlayerSelect name="conversionReceiverId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionReceiverId || 'null'} />
-          <p>Rusher:</p>
-          <PlayerSelect name="conversionRusherId" players={(playerWithBall.teamId === homeTeam.id ? homeTeam : awayTeam).players} onChange={handleChange} value={formData.conversionRusherId || 'null'} />
-          <label>
-            Conversion Good:
-            <input type="checkbox" name="conversionGood" value={!formData.conversionGood} checked={formData.conversionGood} onChange={handleChange} />
-          </label>
-        </div>
-        {/* )} */}
-      </div>
-      <div>
-        <label>
-          Defensive Conversion:
-          <input type="checkbox" name="defensiveConversion" value={!formData.defensiveConversion} checked={formData.defensiveConversion} onChange={handleChange} />
-        </label>
-        <p>Returned by</p>
-        <PlayerSelect name="conversionReturnerId" players={(playerWithBall.teamId === homeTeam.id ? awayTeam : homeTeam).players} onChange={handleChange} value={formData.conversionReturnerId || 'null'} />
-      </div>
-      {/* ) */}
-      {/* )
-        } */}
+      {((playerWithBall.teamId === homeTeam.id && formData.fieldPositionEnd === -50) || (playerWithBall.teamId === awayTeam.id && formData.fieldPositionEnd === 50)) && <p>Safety {playerWithBall.teamId === homeTeam.id ? `${awayTeam.locationName} ${awayTeam.nickname}` : `${homeTeam.locationName} ${homeTeam.nickname}`}!</p>}
       <div className="playform-buttons">
         {submitFormData === null && <div>Play is incomplete or illogical, double check form before submission</div>}
         <button type="submit" disabled={!submitFormData}>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,6 +6,13 @@ body {
 .playform {
   width: 700px;
   margin: 10px auto;
+  .pf-section {
+    width: 100%;
+    border: 2px solid gray;
+    border-radius: 10px;
+    padding: 10px;
+    margin-top: 10px;
+  }
   .playform-team-select {
     display: flex;
     justify-content: space-evenly;
@@ -30,12 +37,16 @@ body {
     }
   }
   .pf-field-position {
+
+    position: relative;
     display: flex;
     flex-flow: column;
     gap: 5px;
     align-items: flex-end;
+    margin: 5px 0;
     .pf-field-position-slider {
       -webkit-appearance: none;
+      z-index: 2;
       appearance: none;
       width: 100%;
       height: 5px;
@@ -97,6 +108,13 @@ body {
       border: 0;
     }
     .pf-field-position-clear {
+      position: absolute;
+      z-index: 1;
+      right: 0;
+      top: -26px;
+      height: 19px;
+      font-size: 0.7rem;
+      line-height: 1;
       background: black;
       border-radius: 5px;
       border: 1px solid red;
@@ -136,8 +154,78 @@ body {
     height: 30px;
     outline: 1px solid greenyellow;
   }
-  /* .playform-timebox:focus-visible {
-  } */
+  .pf-creator-header {
+    display: flex;
+    height: auto;
+    align-items: baseline;
+    border-bottom: 1px solid greenyellow;
+    padding-bottom: 8px;
+    margin-bottom: 4px;
+    p {
+      height: 20px;
+      margin-bottom: 0;
+    }
+    button {
+      background: none;
+      border-radius: 5px;
+      border: 1px solid greenyellow;
+      color: greenyellow;
+      padding: 5px;
+      line-height: 0.5;
+      margin-left: 6px;
+    }
+  }
+  .pf-creator-form {
+    width: 100%;
+    padding: 5px 0;
+    border-bottom: 1px solid greenyellow;
+    padding-bottom: 8px;
+    margin-bottom: 4px;
+    p {
+      margin-bottom: 0;
+    }
+    .pf-creator-form-add {
+      background: none;
+      border-radius: 5px;
+      border: 2px solid gray;
+      color: greenyellow;
+      padding: 5px;
+      line-height: 0.8;
+      width: 50px;
+      margin-top: 4px;
+      margin-left: calc(50% - 25px);
+    }
+    .pf-lc-s1 {
+      display: flex;
+      gap: 10px;
+    }
+     {}
+  }
+  .pf-creator-collection {
+    .pf-creator-collection-item {
+      display: flex;
+      align-items: center;
+      border-top: 1px solid darkgray;
+      padding: 4px 0;
+      button {
+        background: none;
+        border-radius: 5px;
+        border: 1px solid red;
+        color: greenyellow;
+        padding: 5px;
+        font-size: 0.7rem;
+        line-height: 0.5;
+        margin-right: 6px;
+        height: 20px;
+      }
+      p {
+        margin: 0;
+      }
+    }
+    .pf-creator-collection-item:first-of-type {
+      border-top: none;
+    }
+  }
   label {
     display: flex;
   }
@@ -145,4 +233,38 @@ body {
 
 .player-select {
   display: inline;
+}
+.player-multi {
+  .player-multi-header {
+    display: flex;
+    p {
+      margin: 0 10px 0 0;
+    }
+  }
+  .player-multi-collection {
+    .player-multi-collection-item {
+      display: flex;
+      align-items: center;
+      padding-top: 5px;
+      height: auto;
+      button {
+        background: none;
+        border-radius: 5px;
+        border: 1px solid red;
+        color: greenyellow;
+        padding: 5px;
+        font-size: 0.7rem;
+        line-height: 0.5;
+        margin-right: 6px;
+        height: 20px;
+      }
+      p {
+        margin: 0;
+      }
+    }
+    .player-multi-collection-item:first-of-type {
+      border-top: 1px solid darkgray;
+      margin-top: 5px;
+    }
+  }
 }

--- a/src/utils/statAnalysis.js
+++ b/src/utils/statAnalysis.js
@@ -49,48 +49,8 @@ const parsePlayerPossession = (formData) => {
       return formData.fumbles[unrecoveredIndex].fumbleCommittedById;
     }
   }
-  // if (hasPossession.Count == 0)
-  // {
-  //     if (formData.FieldGoal && formData.KickGood)
-  //     {
-  //         return (formData.TeamId, false);
-  //     }
-  //     FumbleSubmitDTO? notRecovered = formData.Fumbles.SingleOrDefault(f => f.FumbleRecoveredById == null);
-  //     if (notRecovered != null)
-  //     {
-  //         Player? fumbler = await _playerRepository.GetSinglePlayerAsync(notRecovered.FumbleCommittedById);
-  //         if (fumbler == null || (fumbler.TeamId != homeTeamId && fumbler.TeamId != awayTeamId))
-  //         {
-  //             return (0, false);
-  //         }
-  //         if (Math.Abs(formData.FieldPositionEnd ?? 0) == 50)
-  //         {
-  //             return (fumbler.TeamId == homeTeamId ? awayTeamId : homeTeamId, false);
-  //         }
-  //         return (fumbler.TeamId, false);
-  //     }
-  //     if (((formData.Kickoff || formData.Punt) && formData.KickReturnerId == null)
-  //         || (formData.KickBlocked && formData.KickBlockRecoveredById == null))
-  //     {
-  //         return (formData.TeamId == homeTeamId ? awayTeamId : homeTeamId, false);
-  //     }
-  //     return (0, true);
-  // }
 
   return null;
-  // if ((formData.TouchdownPlayerId != null && hasPossession[0] != formData.TouchdownPlayerId)
-  //     || (formData.CedingPlayerId != null && hasPossession[0] != formData.CedingPlayerId))
-  // {
-  //     return (0, true);
-  // }
-
-  // Player? player = await _playerRepository.GetSinglePlayerAsync(hasPossession[0]);
-  // if (player == null || (player.TeamId != homeTeamId && player.TeamId != awayTeamId))
-  // {
-  //     return (0, false);
-  // }
-
-  // return (player.TeamId == homeTeamId ? homeTeamId : awayTeamId, false);
 };
 
 const parsePossessionChanges = (formData) => {

--- a/src/utils/statAnalysis.js
+++ b/src/utils/statAnalysis.js
@@ -94,7 +94,7 @@ const parsePossessionChanges = (formData) => {
   }
 
   if (formData.fumbles.length === 0 && formData.laterals.length === 0) {
-    return possessionChanges;
+    return [possessionChanges];
   }
 
   const toPlace = [];
@@ -174,8 +174,6 @@ const parsePossessionChanges = (formData) => {
 
   const fitFound = checkPlacementLayer(1);
 
-  console.warn(paths);
-
   if (fitFound) {
     return paths
       .filter((path) => path.length === toPlace.length)
@@ -197,7 +195,7 @@ const parsePossessionChanges = (formData) => {
         return newChain;
       });
   }
-  return null;
+  return [[]];
 };
 
 export { parsePlayerPossession, parsePossessionChanges };


### PR DESCRIPTION
Address:
- #12 

Re-added formDisplay behavior with collapsing form sections, formData manipulations are handled in onChange calls, never in handleDisplay

Added kickBlocked, fumbleCreator, lateralCreator, and penaltyCreator to formDisplay

Styling of PlayForm.cs and PlayerMultiSelect.cs elements

Fixed validateFormData where values that should be null were set to false and vice versa
Touchbacks and good/missed field goals do not need manually set fieldPositionEnd values
validateFormData filters out possessionChains where starting player is on wrong team

parsePossessionChanges always returns an array of arrays, empty if no valid possession chains are found