### PR TITLE
Fixed Bug that logged touchdowns on away team kickoffs with touchbacks

### DIFF
--- a/src/components/forms/PlayForm.js
+++ b/src/components/forms/PlayForm.js
@@ -635,7 +635,6 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
         const playerId = parsePlayerPossession(newFormData);
         setPlayerWithBall(playerById(playerId));
       } else {
-        console.warn('nothing');
         setPlayerWithBall({});
       }
     }

--- a/src/components/forms/PlayForm.js
+++ b/src/components/forms/PlayForm.js
@@ -503,7 +503,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
       return null;
     }
 
-    // fieldPositionEnd is set to goalline on made field goals
+    // fieldPositionEnd is set to goalline on made field goals and touchbacks
     // 7 yards back on missed field goals
     // else cannot be null
     if (updatedFormData.kickGood || updatedFormData.kickTouchback) {
@@ -529,7 +529,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     }
 
     // Update touchdown, safety information if a play ends in either endzone
-    if ((!updatedFormData.kickGood && playerWithBall.teamId === homeTeam.id && updatedFormData.fieldPositionEnd === 50) || (playerWithBall.teamId === awayTeam.id && updatedFormData.fieldPositionEnd === -50)) {
+    if (!updatedFormData.kickGood && ((playerWithBall.teamId === homeTeam.id && updatedFormData.fieldPositionEnd === 50) || (playerWithBall.teamId === awayTeam.id && updatedFormData.fieldPositionEnd === -50))) {
       updatedFormData.touchdownPlayerId = playerWithBall.id;
       updatedFormData.conversion = formDisplay.twoPointPass || formDisplay.twoPointRush;
       if (updatedFormData.extraPoint && updatedFormData.conversion && !updatedFormData.extraPointFake) {
@@ -588,7 +588,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
       updatedFormData.conversionReturnerId = null;
     }
 
-    if ((!updatedFormData.kickTouchback && playerWithBall.teamId === awayTeam.id && updatedFormData.fieldPositionEnd === 50) || (playerWithBall.teamId === homeTeam.id && updatedFormData.fieldPositionEnd === -50)) {
+    if (!updatedFormData.kickTouchback && ((playerWithBall.teamId === awayTeam.id && updatedFormData.fieldPositionEnd === 50) || (playerWithBall.teamId === homeTeam.id && updatedFormData.fieldPositionEnd === -50))) {
       updatedFormData.safety = true;
       updatedFormData.cedingPlayerId = playerWithBall.id;
     } else {
@@ -631,9 +631,12 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     if (formData.teamId) {
       const newFormData = validateFormData();
       setSubmitFormData(newFormData);
-      if (newFormData?.teamId) {
+      if (newFormData !== null) {
         const playerId = parsePlayerPossession(newFormData);
         setPlayerWithBall(playerById(playerId));
+      } else {
+        console.warn('nothing');
+        setPlayerWithBall({});
       }
     }
   }, [formData, formDisplay]);


### PR DESCRIPTION
PlayerWithBall was not resetting after touchdowns, so when a touchback occurred, formData logged away team player with ball and parsed fieldPositionEnd being -50 as a touchdown for away team.

setPlayerWithBall to {} in useEffect when formData is updated and submitFormData is null (triggered by on submit)

Adjusted requirements in validatePlayData for touchdown and safety logging