### PR TITLE
Login/Logout Pages, Login Behavior, Tackler Bug

### DIFF
--- a/src/app/games/[gameId]/game-stream/page.js
+++ b/src/app/games/[gameId]/game-stream/page.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types';
 import PlayForm from '../../../../components/forms/PlayForm';
 import { getGameStream } from '../../../../api/gameData';
 import GameStream from '../../../../components/GameStream';
+import Loading from '../../../../components/Loading';
 
 export default function ManageGameStream({ params }) {
   const { gameId } = params;
@@ -21,7 +22,7 @@ export default function ManageGameStream({ params }) {
   }, []);
 
   if (!gameStream.nextPlay) {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   return (

--- a/src/app/games/page.js
+++ b/src/app/games/page.js
@@ -15,7 +15,6 @@ export default function ViewAllGames() {
 
   return (
     <div className="list-container">
-      Game List
       {games.map((game) => (
         <Link key={game.id} href={`/games/${game.id}/game-stream`} className="list-item">
           {/* <hr style={{ color: team.colorPrimaryHex }} />

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,29 +1,32 @@
 'use client';
 
- // any component that uses useAuth needs this because if a component directly imports useAuth, it needs to be a client component since useAuth uses React hooks.
+// any component that uses useAuth needs this because if a component directly imports useAuth, it needs to be a client component since useAuth uses React hooks.
 
-import { Button } from 'react-bootstrap';
 import { signOut } from '@/utils/auth'; // anything in the src dir, you can use the @ instead of relative paths
-import { useAuth } from '@/utils/context/authContext';
+import Link from 'next/link';
 
 function Home() {
-  const { user } = useAuth();
-
   return (
-    <div
-      className="text-center d-flex flex-column justify-content-center align-content-center"
-      style={{
-        height: '90vh',
-        padding: '30px',
-        maxWidth: '400px',
-        margin: '0 auto',
-      }}
-    >
-      <h1>Hello {user.displayName}! </h1>
-      <p>Click the button below to logout!</p>
-      <Button variant="danger" type="button" size="lg" className="copy-btn" onClick={signOut}>
-        Sign Out
-      </Button>
+    <div className="welcome-box">
+      <div className="welcome-logo">
+        <span className="welcome-the">THE</span>
+        <span className="welcome-backfield">BACKFIELD</span>
+      </div>
+      <div className="welcome-buttons">
+        <Link href="/teams">
+          <button className="button" type="button">
+            TEAMS
+          </button>
+        </Link>
+        <Link href="/games">
+          <button className="button" type="button">
+            GAMES
+          </button>
+        </Link>
+        <button className="button button-red" type="button" onClick={signOut}>
+          SIGN OUT
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/app/teams/[teamId]/page.js
+++ b/src/app/teams/[teamId]/page.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getSingleTeam } from '../../../api/teamData';
 import { useAuth } from '../../../utils/context/authContext';
+import Loading from '../../../components/Loading';
 
 export default function ViewTeamInfo({ params }) {
   const [team, setTeam] = useState({});
@@ -15,7 +16,7 @@ export default function ViewTeamInfo({ params }) {
   }, [teamId, user]);
 
   if (!team.id) {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   return (

--- a/src/app/watch/[gameId]/page.js
+++ b/src/app/watch/[gameId]/page.js
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { getGameStream } from '../../../api/gameData';
 import GameStream from '../../../components/GameStream';
+import Loading from '../../../components/Loading';
 
 export default function WatchGameStream({ params }) {
   const { gameId } = params;
@@ -15,10 +16,11 @@ export default function WatchGameStream({ params }) {
 
   useEffect(() => {
     updateGameStream();
-  }, [updateGameStream]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!gameStream.nextPlay) {
-    return <div>Loading...</div>;
+    return <Loading />;
   }
 
   return <GameStream gameStream={gameStream} />;

--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -113,7 +113,7 @@ export default function GameStream({ gameStream }) {
         </div>
       </div>
       <div className="gamestream-field">
-        <div className="gsf-to-gain" style={{ left: 300 - 1 + gameStream.nextPlay.toGain * 5 }} />
+        {gameStream.nextPlay.down > 0 && <div className="gsf-to-gain" style={{ left: 300 - 1 + gameStream.nextPlay.toGain * 5 }} />}
         <div
           className="gsf-drive"
           style={{
@@ -154,25 +154,29 @@ export default function GameStream({ gameStream }) {
           <p>{gameStream.awayTeam.nickname}</p>
         </div>
       </div>
-      <div className="gs-last-play">
-        <div className="gs-last-play-header">
-          <p className="gs-last-play-text">Last Play:</p>
-          {gameStream.lastPlay.down > 0 && (
-            <p className="gs-last-play-down">
-              {gameStream.lastPlay.down === 1 && '1st '}
-              {gameStream.lastPlay.down === 2 && '2nd '}
-              {gameStream.lastPlay.down === 3 && '3rd '}
-              {gameStream.lastPlay.down === 4 && '4th '}& {Math.abs(gameStream.lastPlay.toGain) === 50 ? 'Goal' : (gameStream.lastPlay.toGain - gameStream.lastPlay.fieldPositionStart) * (gameStream.lastPlay.teamId === gameStream.awayTeam.id ? -1 : 1)}
-            </p>
-          )}
-          <p className="gs-last-play-field-position">on {fieldPositionToString(gameStream.lastPlay.fieldPositionStart)}</p>
+      {gameStream.lastPlay !== null && (
+        <div className="gs-last-play">
+          <div className="gs-last-play-header">
+            <p className="gs-last-play-text">Last Play:</p>
+            {gameStream.lastPlay.down > 0 && (
+              <>
+                <p className="gs-last-play-down">
+                  {gameStream.lastPlay.down === 1 && '1st '}
+                  {gameStream.lastPlay.down === 2 && '2nd '}
+                  {gameStream.lastPlay.down === 3 && '3rd '}
+                  {gameStream.lastPlay.down === 4 && '4th '}& {Math.abs(gameStream.lastPlay.toGain) === 50 ? 'Goal' : (gameStream.lastPlay.toGain - gameStream.lastPlay.fieldPositionStart) * (gameStream.lastPlay.teamId === gameStream.awayTeam.id ? -1 : 1)}
+                </p>
+                <p className="gs-last-play-field-position">on {fieldPositionToString(gameStream.lastPlay.fieldPositionStart)}</p>
+              </>
+            )}
+          </div>
+          <div className="play-segments-container">
+            {gameStream.lastPlay.playSegments.map((ps) => (
+              <PlaySegment key={ps.index} playSegment={ps} />
+            ))}
+          </div>
         </div>
-        <div className="play-segments-container">
-          {gameStream.lastPlay.playSegments.map((ps) => (
-            <PlaySegment key={ps.index} playSegment={ps} />
-          ))}
-        </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -24,6 +24,43 @@ export default function GameStream({ gameStream }) {
     return asText;
   };
 
+  const driveFillColor = (edge) => {
+    let color = '';
+    const defaultPrimary = '#a1a1a1';
+    const defaultSecondary = '#d1d1d1';
+    switch (edge) {
+      case 'top':
+        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorPrimaryHex : gameStream.awayTeam.colorPrimaryHex;
+        if (color === '') {
+          color = defaultPrimary;
+        }
+        break;
+      case 'left':
+        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
+          color = gameStream.homeTeam.colorSecondaryHex !== '' ? gameStream.homeTeam.colorSecondaryHex : defaultSecondary;
+        } else {
+          color = gameStream.awayTeam.colorPrimaryHex !== '' ? gameStream.awayTeam.colorPrimaryHex : defaultPrimary;
+        }
+        break;
+      case 'right':
+        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
+          color = gameStream.homeTeam.colorPrimaryHex !== '' ? gameStream.homeTeam.colorPrimaryHex : defaultPrimary;
+        } else {
+          color = gameStream.awayTeam.colorSecondaryHex !== '' ? gameStream.awayTeam.colorSecondaryHex : defaultSecondary;
+        }
+        break;
+      case 'bottom':
+        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorSecondaryHex : gameStream.awayTeam.colorSecondaryHex;
+        if (color === '') {
+          color = defaultSecondary;
+        }
+        break;
+      default:
+        break;
+    }
+    return color !== '' ? color : '#a1a1a1';
+  };
+
   return (
     <div className="game-stream">
       <div className="game-stream-status">
@@ -82,10 +119,10 @@ export default function GameStream({ gameStream }) {
           style={{
             left: 300 - 1 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
             width: gameStream.driveYards * 5,
-            borderTop: `132px solid ${gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorPrimaryHex : gameStream.awayTeam.colorPrimaryHex}`,
-            borderRight: `${(gameStream.driveYards / 2) * 5}px solid ${gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorPrimaryHex : gameStream.awayTeam.colorPrimaryHex}`,
-            borderBottom: `132px solid ${gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorSecondaryHex : gameStream.awayTeam.colorSecondaryHex}`,
-            borderLeft: `${(gameStream.driveYards / 2) * 5 + 1}px solid ${gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorSecondaryHex : gameStream.awayTeam.colorSecondaryHex}`,
+            borderTop: `132px solid ${driveFillColor('top')}`,
+            borderRight: `${(gameStream.driveYards / 2) * 5}px solid ${driveFillColor('right')}`,
+            borderBottom: `132px solid ${driveFillColor('bottom')}`,
+            borderLeft: `${(gameStream.driveYards / 2) * 5 + 1}px solid ${driveFillColor('left')}`,
           }}
         />
         <div

--- a/src/components/Loading.js
+++ b/src/components/Loading.js
@@ -7,7 +7,7 @@ export default function Loading() {
       <Spinner
         animation="border"
         style={{
-          color: '#00BF67',
+          color: '#ADFF2F',
           width: '100px',
           height: '100px',
         }}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -23,7 +23,7 @@ export default function NavBar() {
             GAMES
           </Link>
         </Nav>
-        <button className="button" type="button" onClick={signOut}>
+        <button className="button button-red" type="button" onClick={signOut}>
           SIGN OUT
         </button>
       </Container>

--- a/src/components/NavBarNoAuth.js
+++ b/src/components/NavBarNoAuth.js
@@ -12,7 +12,7 @@ export default function NavBarNoAuth() {
           <span className="nav-the">THE</span>
           <span className="nav-backfield">BACKFIELD</span>
         </Link>
-        <button className="button button-red" type="button" onClick={signIn}>
+        <button className="button" type="button" onClick={signIn}>
           SIGN IN
         </button>
       </Container>

--- a/src/components/PlayerMultiSelect.js
+++ b/src/components/PlayerMultiSelect.js
@@ -11,7 +11,7 @@ export default function PlayerMultiSelect({ name, players, onChange, value, head
   };
 
   useEffect(() => {
-    onChange({ target: { name, value: [] } });
+    onChange({ target: { name, value: value.filter((id) => players.some((p) => p.id === id)) } });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [players]);
 

--- a/src/components/SignIn.js
+++ b/src/components/SignIn.js
@@ -1,23 +1,18 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
 import { signIn } from '../utils/auth';
 
 function Signin() {
   return (
-    <div
-      className="text-center d-flex flex-column justify-content-center align-content-center"
-      style={{
-        height: '90vh',
-        padding: '30px',
-        maxWidth: '400px',
-        margin: '0 auto',
-      }}
-    >
-      <h1>Hi there!</h1>
-      <p>Click the button below to login!</p>
-      <Button type="button" size="lg" className="copy-btn" onClick={signIn}>
-        Sign In
-      </Button>
+    <div className="welcome-box">
+      <div className="welcome-logo">
+        <span className="welcome-the">THE</span>
+        <span className="welcome-backfield">BACKFIELD</span>
+      </div>
+      <div className="welcome-buttons">
+        <button className="button" type="button" onClick={signIn}>
+          SIGN IN
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -470,6 +470,7 @@ body {
   .game-stream-status {
     display: flex;
     width: 100%;
+    min-height: 100px;
     justify-content: space-between;
     align-items: center;
     margin: 10px auto 0 auto;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,6 +8,32 @@ body {
   font-family: Verdana, Geneva, Tahoma, sans-serif;
 }
 
+.welcome-box {
+  width: 450px;
+  height: 150px;
+  box-shadow: inset 0 -55px 5px -50px greenyellow;
+  margin: 30vh auto;
+  .welcome-logo {
+    display: flex;
+    justify-content: center;
+    font-size: 3rem;
+    font-weight: bold;
+    margin-bottom: 10px;
+    .welcome-the {
+      color: white;
+    }
+    .welcome-backfield {
+      color: greenyellow;
+    }
+  }
+  .welcome-buttons {
+    display: flex;
+    justify-content: space-evenly;
+    width: 100%;
+    font-size: 1.2rem;
+  }
+}
+
 .nav {
   box-shadow: inset 0 -8px 10px -5px greenyellow;
   font-family: Verdana, Helvetica, sans-serif;

--- a/src/utils/context/ViewDirector.js
+++ b/src/utils/context/ViewDirector.js
@@ -29,7 +29,7 @@ function ViewDirectorBasedOnUserAuthStatus({ children }) {
   if (user) {
     return (
       <>
-        <NavBar /> {/* NavBar only visible if user is logged in and is in every view */}
+        {pathname !== '/' && <NavBar />} {/* NavBar only visible if user is logged in and is in every view */}
         {user.sessionKey ? children : <UserForm />}
       </>
     );

--- a/src/utils/context/authContext.js
+++ b/src/utils/context/authContext.js
@@ -45,6 +45,7 @@ function AuthProvider(props) {
           hasLoggedIn.current = true;
         }
       } else {
+        hasLoggedIn.current = false;
         setOAuthUser(false);
         setUser(false);
       }


### PR DESCRIPTION
Styled login/logout and home pages to show simple logo and options
Home page does not display navbar, only simple options below centered logo

Addressed bug where page was not redirecting to correct view on login

Changed useEffect behavior in PlayerMultiSelect to remove only players that aren't in new list
Relieved Tackler Select of strict dependence on playerWithBall's existence

Incomplete passes no longer require explicit fieldPositionEnd (set to fieldPositionStart, slider disappears) unless tacklers are defined (meaning a sack)

Replaced "Loading..." messages with spinner component