### PR TITLE
Delete previous play from PlayForm, styling

### DIFF
--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -113,16 +113,22 @@ export default function GameStream({ gameStream }) {
         </div>
       </div>
       <div className="gamestream-field">
-        {gameStream.nextPlay.down > 0 && <div className="gsf-to-gain" style={{ left: 300 - 1 + gameStream.nextPlay.toGain * 5 }} />}
+        {gameStream.nextPlay.down > 0 && <div className="gsf-to-gain" style={{ left: 300 + gameStream.nextPlay.toGain * 5 }} />}
+        <div
+          className="gsf-ball-on"
+          style={{
+            left: 300 + gameStream.nextPlay.fieldPositionStart * 5,
+          }}
+        />
         <div
           className="gsf-drive"
           style={{
-            left: 300 - 1 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
-            width: gameStream.driveYards * 5,
+            left: 300 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
+            width: Math.max(gameStream.driveYards, 0) * 5,
             borderTop: `132px solid ${driveFillColor('top')}`,
-            borderRight: `${(gameStream.driveYards / 2) * 5}px solid ${driveFillColor('right')}`,
+            borderRight: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('right')}`,
             borderBottom: `132px solid ${driveFillColor('bottom')}`,
-            borderLeft: `${(gameStream.driveYards / 2) * 5 + 1}px solid ${driveFillColor('left')}`,
+            borderLeft: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('left')}`,
           }}
         />
         <div
@@ -133,7 +139,6 @@ export default function GameStream({ gameStream }) {
         >
           <p>{gameStream.homeTeam.nickname}</p>
         </div>
-        <div className="gsf-yardline" />
         <div className="gsf-yardline" />
         <div className="gsf-yardline" />
         <div className="gsf-yardline" />

--- a/src/components/PlaySegment.js
+++ b/src/components/PlaySegment.js
@@ -17,18 +17,17 @@ export default function PlaySegment({ playSegment }) {
           <div className="gsf-yardline" />
           <div className="gsf-yardline" />
           <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
           <div
             className="play-segment-line"
             style={{
               width: Math.abs(playSegment.fieldEnd - playSegment.fieldStart) * 5,
-              left: 300 - 1 + (playSegment.fieldEnd > playSegment.fieldStart ? playSegment.fieldStart : playSegment.fieldEnd) * 5,
+              left: 300 + (playSegment.fieldEnd > playSegment.fieldStart ? playSegment.fieldStart : playSegment.fieldEnd) * 5,
             }}
           />
           <div
             className="play-segment-marker"
             style={{
-              left: 300 - 5 + playSegment.fieldEnd * 5,
+              left: 300 - 4 + playSegment.fieldEnd * 5,
             }}
           />
         </div>

--- a/src/components/forms/PlayForm.js
+++ b/src/components/forms/PlayForm.js
@@ -2,7 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useAuth } from '../../utils/context/authContext';
-import { createPlay } from '../../api/playData';
+import { createPlay, deletePlay } from '../../api/playData';
 import PlayerSelect from '../PlayerSelect';
 import FieldPositionSlider from '../FieldPositionSlider';
 import { parsePlayerPossession, parsePossessionChanges } from '../../utils/statAnalysis';
@@ -399,6 +399,10 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     const reset = playEdit || initialState;
     setFormData(() => ({ ...reset, sessionKey: user.sessionKey, gameId }));
     setFormDisplay(initialDisplay);
+    setPlayerWithBall({});
+    setFumbleCreator(initialFumbleCreator);
+    setLateralCreator(initialLateralCreator);
+    setPenaltyCreator(initialPenaltyCreator);
   };
 
   const selectiveReset = (keys = []) => {
@@ -617,9 +621,17 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
       createPlay(submitFormData).then(() => {
         onUpdate();
         allReset();
-        setNewPlay((prev) => !prev);
+        setNewPlay(false);
       });
     }
+  };
+
+  const handlePlayDelete = () => {
+    deletePlay(playEdit.prevPlayId, user.sessionKey).then(() => {
+      onUpdate();
+      allReset();
+      setNewPlay(false);
+    });
   };
 
   useEffect(() => {
@@ -656,6 +668,11 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
           <button className="button" type="button" onClick={() => setNewPlay((prev) => !prev)}>
             Add Play
           </button>
+          {playEdit.prevPlayId !== -1 && (
+            <button className="button button-red" type="button" onClick={handlePlayDelete}>
+              Delete Last Play
+            </button>
+          )}
         </div>
       </div>
     );
@@ -1321,12 +1338,17 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
         <button className="button" type="submit" disabled={!submitFormData}>
           Submit
         </button>
-        <button className="button button-red" type="button" onClick={allReset}>
-          Reset
-        </button>
         <button className="button" type="button" onClick={() => setNewPlay(false)}>
           Collapse Form
         </button>
+        <button className="button button-red" type="button" onClick={allReset}>
+          Reset Form
+        </button>
+        {playEdit.prevPlayId !== -1 && (
+          <button className="button button-red" type="button" onClick={handlePlayDelete}>
+            Delete Last Play
+          </button>
+        )}
       </div>
     </form>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -581,6 +581,7 @@ body {
   .gamestream-field {
     position: relative;
     display: flex;
+    justify-content: space-evenly;
     width: 604px;
     height: 267px;
     /* border: 2px solid #45ff12; */
@@ -601,11 +602,21 @@ body {
       left: 50%;
       z-index: -2;
     }
+    .gsf-ball-on {
+      position: absolute;
+      height: 100%;
+      width: 0;
+      border: 1px solid greenyellow;
+      left: 50%;
+    }
     .gsf-yardline {
       height: 100%;
-      width: 50px;
-      border-left: 1px solid white;
-      z-index: -1;
+      width: 0px;
+      border: 1px solid white;
+      z-index: -2;
+    }
+    :nth-child(1 of .gsf-yardline), :nth-last-child(1 of .gsf-yardline) {
+      border: 1px solid greenyellow;
     }
     .gsf-home-team-endzone, .gsf-away-team-endzone {
       position: absolute;
@@ -613,7 +624,7 @@ body {
       height: 100%;
       width: 50px;
       background: linear-gradient();
-      z-index: 2;
+      z-index: -3;
       p {
         margin: 0 auto;
         height: 263px;


### PR DESCRIPTION
While on the /games/{gameId}/game-stream page, there is a button to delete the previous play from the gamestream

Updated allReset() to include [Fumble/Lateral/Penalty]Creators and playerWithBall returning to initial states, and always setNextPlay to false

Reorganized and styled gamestream field, added marker for line of scrimmage, and prevented width calculations for drive from going negative when overall yardage is negative