### PR TITLE
GameStream Displays Player Stats in StatBar

### DIFF
--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -1,8 +1,11 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import PlaySegment from './PlaySegment';
+import StatBar from './StatBar';
 
 export default function GameStream({ gameStream }) {
+  const [expandedStats, setExpandedStats] = useState(false);
+
   const fieldPositionToString = (fpAsInt) => {
     if (fpAsInt == null) {
       return '';
@@ -182,6 +185,156 @@ export default function GameStream({ gameStream }) {
           </div>
         </div>
       )}
+      <StatBar homeTeamStats={gameStream.homeTeamPlayerStats} awayTeamStats={gameStream.awayTeamPlayerStats} lastPlay={gameStream.lastPlay}>
+        <StatBar.Section>
+          <StatBar.Column>
+            <StatBar.Ticker teamStats={gameStream.homeTeamPlayerStats} lastPlay={gameStream.lastPlay} />
+          </StatBar.Column>
+          <StatBar.Column>
+            <StatBar.Ticker teamStats={gameStream.awayTeamPlayerStats} lastPlay={gameStream.lastPlay} />
+          </StatBar.Column>
+        </StatBar.Section>
+        <button type="button" className="sb-expand" onClick={() => setExpandedStats((prev) => !prev)}>
+          {expandedStats ? 'Collapse Stats' : 'Expand Stats'}
+        </button>
+        {expandedStats && (
+          <>
+            <StatBar.Section title="Passing">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.passAttempts !== 0)
+                  .sort((a, b) => b.passYards - a.passYards)
+                  .map((player) => (
+                    <StatBar.Passer player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.passAttempts !== 0)
+                  .sort((a, b) => b.passYards - a.passYards)
+                  .map((player) => (
+                    <StatBar.Passer player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Receiving">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.receivingTargets !== 0 || player.receivingYards !== 0)
+                  .sort((a, b) => b.receptions - a.receptions)
+                  .sort((a, b) => b.receivingYards - a.receivingYards)
+                  .map((player) => (
+                    <StatBar.Receiver player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.receivingTargets !== 0 || player.receivingYards !== 0)
+                  .sort((a, b) => b.receivingYards - a.receivingYards)
+                  .map((player) => (
+                    <StatBar.Receiver player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Rushing">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.rushAttempts !== 0 || player.rushYards !== 0)
+                  .sort((a, b) => b.rushYards - a.rushYards)
+                  .map((player) => (
+                    <StatBar.Rusher player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.rushAttempts !== 0 || player.rushYards !== 0)
+                  .sort((a, b) => b.rushYards - a.rushYards)
+                  .map((player) => (
+                    <StatBar.Rusher player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Kicking">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.fieldGoalAttempts !== 0 || player.extraPointAttempts !== 0)
+                  .sort((a, b) => b.fieldGoalAttempts - a.fieldGoalAttempts)
+                  .map((player) => (
+                    <StatBar.Kicker player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.fieldGoalAttempts !== 0 || player.extraPointAttempts !== 0)
+                  .sort((a, b) => b.fieldGoalAttempts - a.fieldGoalAttempts)
+                  .map((player) => (
+                    <StatBar.Kicker player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Punting">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.punts !== 0)
+                  .sort((a, b) => b.punts - a.punts)
+                  .map((player) => (
+                    <StatBar.Punter player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.punts !== 0)
+                  .sort((a, b) => b.punts - a.punts)
+                  .map((player) => (
+                    <StatBar.Punter player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Returns">
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.kickoffReturns !== 0 || player.puntReturns !== 0)
+                  .sort((a, b) => b.puntReturnYards - a.puntReturnYards)
+                  .sort((a, b) => b.kickoffReturnYards - a.kickoffReturnYards)
+                  .map((player) => (
+                    <StatBar.Returner player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.kickoffReturns !== 0 || player.puntReturns !== 0)
+                  .sort((a, b) => b.puntReturns - a.puntReturns)
+                  .sort((a, b) => b.kickoffReturns - a.kickoffReturns)
+                  .map((player) => (
+                    <StatBar.Returner player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+            <StatBar.Section title="Defense" divider={false}>
+              <StatBar.Column>
+                {gameStream.homeTeamPlayerStats
+                  .filter((player) => player.tackles !== 0 || player.sacks !== 0 || player.interceptionsReceived !== 0 || player.fumbleReturnTouchdowns !== 0)
+                  .sort((a, b) => b.interceptionsReceived - a.interceptionsReceived)
+                  .sort((a, b) => b.sacks - a.sacks)
+                  .sort((a, b) => b.tackles - a.tackles)
+                  .map((player) => (
+                    <StatBar.Defender player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+              <StatBar.Column>
+                {gameStream.awayTeamPlayerStats
+                  .filter((player) => player.tackles !== 0 || player.sacks !== 0 || player.interceptionsReceived !== 0 || player.fumbleReturnTouchdowns !== 0)
+                  .sort((a, b) => b.interceptionsReceived - a.interceptionsReceived)
+                  .sort((a, b) => b.sacks - a.sacks)
+                  .sort((a, b) => b.tackles - a.tackles)
+                  .map((player) => (
+                    <StatBar.Defender player={player} key={player.id} />
+                  ))}
+              </StatBar.Column>
+            </StatBar.Section>
+          </>
+        )}
+      </StatBar>
     </div>
   );
 }
@@ -197,8 +350,8 @@ GameStream.propTypes = {
       colorPrimaryHex: PropTypes.string,
       colorSecondaryHex: PropTypes.string,
     }),
+    homeTeamPlayerStats: PropTypes.shape,
     homeTeamScore: PropTypes.number,
-    awayTeamScore: PropTypes.number,
     awayTeam: PropTypes.shape({
       id: PropTypes.number,
       locationName: PropTypes.string,
@@ -206,6 +359,8 @@ GameStream.propTypes = {
       colorPrimaryHex: PropTypes.string,
       colorSecondaryHex: PropTypes.string,
     }),
+    awayTeamPlayerStats: PropTypes.shape,
+    awayTeamScore: PropTypes.number,
     drivePlays: PropTypes.number,
     drivePositionStart: PropTypes.number,
     driveYards: PropTypes.number,

--- a/src/components/StatBar.js
+++ b/src/components/StatBar.js
@@ -1,0 +1,366 @@
+'use client';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function StatBar({ children }) {
+  return (
+    <div className="stat-bar">
+      <div className="stat-bar-interior-wrapper">{children}</div>
+    </div>
+  );
+}
+
+StatBar.propTypes = {
+  children: PropTypes.node,
+};
+
+StatBar.Section = function Section({ title = '', divider = true, children }) {
+  return (
+    <div className="stat-bar-section">
+      {title !== '' && <p className="stat-bar-section-title">{title}</p>}
+      <div className="stat-bar-section-content">{children}</div>
+      {divider && <hr className="stat-bar-section-divider" />}
+    </div>
+  );
+};
+
+StatBar.Section.propTypes = {
+  title: PropTypes.string,
+  divider: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+StatBar.Column = function Column({ children }) {
+  return <div className="stat-bar-column">{children}</div>;
+};
+
+StatBar.Column.propTypes = {
+  children: PropTypes.node,
+};
+
+StatBar.Ticker = function Ticker({ teamStats, lastPlay }) {
+  return (
+    <>
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.passerId)
+        .map((player) => (
+          <StatBar.Passer key={player.playerId} player={player} />
+        ))}
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.receiverId)
+        .map((player) => (
+          <StatBar.Receiver key={player.playerId} player={player} />
+        ))}
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.rusherId)
+        .map((player) => (
+          <StatBar.Rusher key={player.playerId} player={player} />
+        ))}
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.kickerId)
+        .map((player) => {
+          if (lastPlay.punt) {
+            return <StatBar.Punter key={player.playerId} player={player} />;
+          } 
+            return <StatBar.Kicker key={player.playerId} player={player} />;
+          
+        })}
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.kickReturnerId)
+        .map((player) => (
+          <StatBar.Returner key={player.playerId} player={player} />
+        ))}
+      {teamStats
+        .filter((player) => lastPlay.tacklerIds.includes(player.playerId) || lastPlay.interceptedById === player.playerId)
+        .map((player) => (
+          <StatBar.Defender key={player.playerId} player={player} />
+        ))}
+      {teamStats
+        .filter((player) => player.playerId === lastPlay.extraPointKickerId)
+        .map((player) => (
+          <StatBar.Kicker key={player.playerId} player={player} />
+        ))}
+    </>
+  );
+};
+
+StatBar.Ticker.propTypes = {
+  teamStats: PropTypes.arrayOf(
+    PropTypes.shape({
+      playerId: PropTypes.number,
+    }),
+  ).isRequired,
+  lastPlay: PropTypes.shape({
+    passerId: PropTypes.number,
+    rusherId: PropTypes.number,
+    receiverId: PropTypes.number,
+    kickerId: PropTypes.number,
+    punt: PropTypes.bool,
+    kickReturnerId: PropTypes.number,
+    tacklerIds: PropTypes.arrayOf(PropTypes.number),
+    interceptedById: PropTypes.number,
+    extraPointKickerId: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Passer = function Passer({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat wide">
+        {player.passCompletions}
+        <span style={{ color: 'greenyellow' }}>/</span>
+        {player.passAttempts}
+        <span className="sbhi-units">PASS</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.passYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.passTouchdowns}
+        <span className="sbhi-units">TD</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.interceptionsThrown}
+        <span className="sbhi-units">INT</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Passer.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    passAttempts: PropTypes.number,
+    passCompletions: PropTypes.number,
+    passYards: PropTypes.number,
+    passTouchdowns: PropTypes.number,
+    interceptionsThrown: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Receiver = function Receiver({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat wide">
+        {player.receptions}
+        <span style={{ color: 'greenyellow' }}>/</span>
+        {player.receivingTargets}
+        <span className="sbhi-units">REC</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.receivingYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.receivingTouchdowns}
+        <span className="sbhi-units">TD</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Receiver.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    receptions: PropTypes.number,
+    receivingTargets: PropTypes.number,
+    receivingYards: PropTypes.number,
+    receivingTouchdowns: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Rusher = function Rusher({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat">
+        {player.rushAttempts}
+        <span className="sbhi-units">RUSH</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.rushYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.rushTouchdowns}
+        <span className="sbhi-units">TD</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Rusher.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    rushAttempts: PropTypes.number,
+    rushYards: PropTypes.number,
+    rushTouchdowns: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Defender = function Defender({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat">
+        {player.tackles}
+        <span className="sbhi-units">TCKL</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.sacks}
+        <span className="sbhi-units">SACK</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.interceptionsReceived}
+        <span className="sbhi-units">INT</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.interceptionReturnTouchdowns + player.fumbleReturnTouchdowns}
+        <span className="sbhi-units">TD</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Defender.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    tackles: PropTypes.number,
+    sacks: PropTypes.number,
+    interceptionsReceived: PropTypes.number,
+    interceptionReturnTouchdowns: PropTypes.number,
+    fumbleReturnTouchdowns: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Kicker = function Kicker({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat">
+        {player.fieldGoalAttempts}
+        <span style={{ color: 'greenyellow' }}>/</span>
+        {player.fieldGoalsMade}
+        <span className="sbhi-units">FG</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.extraPointAttempts}
+        <span style={{ color: 'greenyellow' }}>/</span>
+        {player.extraPointsMade}
+        <span className="sbhi-units">XP</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Kicker.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    fieldGoalAttempts: PropTypes.number,
+    fieldGoalsMade: PropTypes.number,
+    extraPointAttempts: PropTypes.number,
+    extraPointsMade: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Punter = function Punter({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat">
+        {player.punts}
+        <span className="sbhi-units">PUNT</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.puntYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+      <span className="sbhi-stat wide">
+        {player.averagePuntYards.toFixed(1)}
+        <span className="sbhi-units">AVG</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Punter.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    punts: PropTypes.number,
+    puntYards: PropTypes.number,
+    averagePuntYards: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Returner = function Returner({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat wide">
+        {player.puntReturns}
+        <span className="sbhi-units">PUNT RET</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.puntReturnYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+      <span className="sbhi-stat wide">
+        {player.kickoffReturns}
+        <span className="sbhi-units">KICK RET</span>
+      </span>
+      <span className="sbhi-stat">
+        {player.kickoffReturnYards}
+        <span className="sbhi-units">YDS</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Returner.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    kickoffReturns: PropTypes.number,
+    kickoffReturnYards: PropTypes.number,
+    puntReturns: PropTypes.number,
+    puntReturnYards: PropTypes.number,
+  }).isRequired,
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -671,6 +671,85 @@ body {
   }
 }
 
+.stat-bar {
+  width: 100%;
+  text-align: center;
+  .stat-bar-interior-wrapper {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+    min-width: 604px;
+    margin: 0 auto;
+    border: 2px solid gray;
+    border-radius: 5px;
+    .stat-bar-section {
+      margin: 3px 0;
+      .stat-bar-section-title {
+        font-size: 0.8rem;
+        font-weight: bold;
+        color: white;
+        margin: 0;
+      }
+      .stat-bar-section-content {
+        height: auto;
+        min-height: 20px;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        margin-bottom: 3px;
+        .stat-bar-column {
+          min-width: 50%;
+        }
+        .stat-bar-column:first-of-type {
+          border-right: 2px solid gray;
+        }
+        .sb-header-item {
+          display: flex;
+          gap: 1px;
+          margin: 3px 8px;
+          justify-content: right;
+          font-size: 0.8rem;
+          .sbhi-player-name {
+            font-weight: bold;
+            text-align: left;
+            flex-grow: 1;
+          }
+          .sbhi-stat {
+            min-width: 50px;
+            text-align: right;
+            .sbhi-units {
+              margin-left: 3px;
+              font-size: 0.5rem;
+              color: greenyellow;
+              font-weight: bold;
+            }
+          }
+          .sbhi-stat.thin {
+            min-width: 35px;
+          }
+          .sbhi-stat.wide {
+            min-width: 70px;
+          }
+        }
+      }
+      .stat-bar-section-divider {
+        border-top: 2px solid gray;
+        opacity: 1;
+        margin: 0 3px;
+      }
+    }
+    .sb-expand {
+      font-size: 0.8rem;
+      background: none;
+      color: greenyellow;
+      border: none;
+      margin: 0 0 3px 0;
+    }
+    .sb-expand:hover {
+      font-weight: bold;
+    }
+  }
+}
+
 .play-segment {
   .play-segment-line {
     position: absolute;


### PR DESCRIPTION
Created StatBar compound component to hold player stats for the game within the GameStream component (visible on both games/[gameId]/gamestream and watch/[gameId] pages), utilizing playerStats from GetGameStream call

StatBar.Ticker shows relevant stats for players involved in the last play. Full stats can be revealed/hidden by clicking Expand Stats/Collapse Stats button just below the Ticker.

Styling of the StatBar and its constituents