### PR TITLE
GameStreamContext, Componentized GameStreamField, StatBar.Fumble

### DIFF
--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import PlaySegment from './PlaySegment';
 import StatBar from './StatBar';
+import GameStreamField from './GameStreamField';
+import { GameStreamProvider } from '../utils/context/gameStreamContext.js';
 
 export default function GameStream({ gameStream }) {
   const [expandedStats, setExpandedStats] = useState(false);
@@ -25,43 +27,6 @@ export default function GameStream({ gameStream }) {
     }
 
     return asText;
-  };
-
-  const driveFillColor = (edge) => {
-    let color = '';
-    const defaultPrimary = '#a1a1a1';
-    const defaultSecondary = '#d1d1d1';
-    switch (edge) {
-      case 'top':
-        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorPrimaryHex : gameStream.awayTeam.colorPrimaryHex;
-        if (color === '') {
-          color = defaultPrimary;
-        }
-        break;
-      case 'left':
-        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
-          color = gameStream.homeTeam.colorSecondaryHex !== '' ? gameStream.homeTeam.colorSecondaryHex : defaultSecondary;
-        } else {
-          color = gameStream.awayTeam.colorPrimaryHex !== '' ? gameStream.awayTeam.colorPrimaryHex : defaultPrimary;
-        }
-        break;
-      case 'right':
-        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
-          color = gameStream.homeTeam.colorPrimaryHex !== '' ? gameStream.homeTeam.colorPrimaryHex : defaultPrimary;
-        } else {
-          color = gameStream.awayTeam.colorSecondaryHex !== '' ? gameStream.awayTeam.colorSecondaryHex : defaultSecondary;
-        }
-        break;
-      case 'bottom':
-        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorSecondaryHex : gameStream.awayTeam.colorSecondaryHex;
-        if (color === '') {
-          color = defaultSecondary;
-        }
-        break;
-      default:
-        break;
-    }
-    return color !== '' ? color : '#a1a1a1';
   };
 
   return (
@@ -102,7 +67,7 @@ export default function GameStream({ gameStream }) {
         </div>
       </div>
       <div className="gs-drive-info-topline">
-        <div className="game-stream-drive-info" style={gameStream.nextPlay.teamId === gameStream.awayTeam.id ? { right: 0 } : { left: 0 }}>
+        <div className={`game-stream-drive-info ${expandedStats && 'gsdi-upper'}`} style={gameStream.nextPlay.teamId === gameStream.awayTeam.id ? { right: 0 } : { left: 0 }}>
           <h4 className="game-stream-current-drive-header">Current Drive</h4>
           <p>
             {gameStream.drivePlays} Play{gameStream.drivePlays !== 1 && 's'}
@@ -115,53 +80,9 @@ export default function GameStream({ gameStream }) {
           </p>
         </div>
       </div>
-      <div className="gamestream-field">
-        {gameStream.nextPlay.down > 0 && <div className="gsf-to-gain" style={{ left: 300 + gameStream.nextPlay.toGain * 5 }} />}
-        <div
-          className="gsf-ball-on"
-          style={{
-            left: 300 + gameStream.nextPlay.fieldPositionStart * 5,
-          }}
-        />
-        <div
-          className="gsf-drive"
-          style={{
-            left: 300 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
-            width: Math.max(gameStream.driveYards, 0) * 5,
-            borderTop: `132px solid ${driveFillColor('top')}`,
-            borderRight: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('right')}`,
-            borderBottom: `132px solid ${driveFillColor('bottom')}`,
-            borderLeft: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('left')}`,
-          }}
-        />
-        <div
-          className="gsf-home-team-endzone"
-          style={{
-            background: `linear-gradient(${gameStream.homeTeam.colorPrimaryHex} 25%, ${gameStream.homeTeam.colorSecondaryHex} 75%)`,
-          }}
-        >
-          <p>{gameStream.homeTeam.nickname}</p>
-        </div>
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div className="gsf-yardline" />
-        <div
-          className="gsf-away-team-endzone"
-          style={{
-            background: `linear-gradient(${gameStream.awayTeam.colorPrimaryHex} 25%, ${gameStream.awayTeam.colorSecondaryHex} 75%)`,
-          }}
-        >
-          <p>{gameStream.awayTeam.nickname}</p>
-        </div>
-      </div>
+      <GameStreamProvider gameStream={gameStream}>
+        <GameStreamField drive slim={expandedStats} toGain ballOn />
+      </GameStreamProvider>
       {gameStream.lastPlay !== null && (
         <div className="gs-last-play">
           <div className="gs-last-play-header">

--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -82,30 +82,30 @@ export default function GameStream({ gameStream }) {
       </div>
       <GameStreamProvider gameStream={gameStream}>
         <GameStreamField drive slim={expandedStats} toGain ballOn />
+        {gameStream.lastPlay !== null && (
+          <div className="gs-last-play">
+            <div className="gs-last-play-header">
+              <p className="gs-last-play-text">Last Play:</p>
+              {gameStream.lastPlay.down > 0 && (
+                <>
+                  <p className="gs-last-play-down">
+                    {gameStream.lastPlay.down === 1 && '1st '}
+                    {gameStream.lastPlay.down === 2 && '2nd '}
+                    {gameStream.lastPlay.down === 3 && '3rd '}
+                    {gameStream.lastPlay.down === 4 && '4th '}& {Math.abs(gameStream.lastPlay.toGain) === 50 ? 'Goal' : (gameStream.lastPlay.toGain - gameStream.lastPlay.fieldPositionStart) * (gameStream.lastPlay.teamId === gameStream.awayTeam.id ? -1 : 1)}
+                  </p>
+                  <p className="gs-last-play-field-position">on {fieldPositionToString(gameStream.lastPlay.fieldPositionStart)}</p>
+                </>
+              )}
+            </div>
+            <div className="play-segments-container">
+              {gameStream.lastPlay.playSegments.map((ps) => (
+                <PlaySegment key={ps.index} playSegment={ps} />
+              ))}
+            </div>
+          </div>
+        )}
       </GameStreamProvider>
-      {gameStream.lastPlay !== null && (
-        <div className="gs-last-play">
-          <div className="gs-last-play-header">
-            <p className="gs-last-play-text">Last Play:</p>
-            {gameStream.lastPlay.down > 0 && (
-              <>
-                <p className="gs-last-play-down">
-                  {gameStream.lastPlay.down === 1 && '1st '}
-                  {gameStream.lastPlay.down === 2 && '2nd '}
-                  {gameStream.lastPlay.down === 3 && '3rd '}
-                  {gameStream.lastPlay.down === 4 && '4th '}& {Math.abs(gameStream.lastPlay.toGain) === 50 ? 'Goal' : (gameStream.lastPlay.toGain - gameStream.lastPlay.fieldPositionStart) * (gameStream.lastPlay.teamId === gameStream.awayTeam.id ? -1 : 1)}
-                </p>
-                <p className="gs-last-play-field-position">on {fieldPositionToString(gameStream.lastPlay.fieldPositionStart)}</p>
-              </>
-            )}
-          </div>
-          <div className="play-segments-container">
-            {gameStream.lastPlay.playSegments.map((ps) => (
-              <PlaySegment key={ps.index} playSegment={ps} />
-            ))}
-          </div>
-        </div>
-      )}
       <StatBar homeTeamStats={gameStream.homeTeamPlayerStats} awayTeamStats={gameStream.awayTeamPlayerStats} lastPlay={gameStream.lastPlay}>
         {expandedStats && (
           <>

--- a/src/components/GameStreamField.js
+++ b/src/components/GameStreamField.js
@@ -104,29 +104,4 @@ GameStreamField.propTypes = {
   drive: PropTypes.bool,
   toGain: PropTypes.bool,
   ballOn: PropTypes.bool,
-  playSegment: PropTypes.shape({
-    index: PropTypes.number,
-    fieldStart: PropTypes.number,
-    fieldEnd: PropTypes.number,
-    teamId: PropTypes.number,
-    segmentText: PropTypes.string,
-    lineType: PropTypes.string,
-    endpointType: PropTypes.string,
-  }).isRequired,
 };
-
-// GameStreamField.Drive = function Drive () {
-//   return (
-//     <div
-//           className="gsf-drive"
-//           style={{
-//             left: 300 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
-//             width: Math.max(gameStream.driveYards, 0) * 5,
-//             borderTop: `132px solid ${driveFillColor('top')}`,
-//             borderRight: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('right')}`,
-//             borderBottom: `132px solid ${driveFillColor('bottom')}`,
-//             borderLeft: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('left')}`,
-//           }}
-//         />
-//   )
-// }

--- a/src/components/GameStreamField.js
+++ b/src/components/GameStreamField.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useGameStream } from '../utils/context/gameStreamContext.js';
 
-export default function GameStreamField({ slim = false, drive = false, toGain = false, ballOn = false }) {
+export default function GameStreamField({ children, slim = false, drive = false, toGain = false, ballOn = false }) {
   const gameStream = useGameStream();
 
   const driveFillColor = (edge) => {
@@ -93,11 +93,13 @@ export default function GameStreamField({ slim = false, drive = false, toGain = 
       >
         {!slim && <p>{gameStream.awayTeam.nickname}</p>}
       </div>
+      {children}
     </div>
   );
 }
 
 GameStreamField.propTypes = {
+  children: PropTypes.node,
   slim: PropTypes.bool,
   drive: PropTypes.bool,
   toGain: PropTypes.bool,

--- a/src/components/GameStreamField.js
+++ b/src/components/GameStreamField.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useGameStream } from '../utils/context/gameStreamContext.js';
+
+export default function GameStreamField({ slim = false, drive = false, toGain = false, ballOn = false }) {
+  const gameStream = useGameStream();
+
+  const driveFillColor = (edge) => {
+    let color = '';
+    const defaultPrimary = '#a1a1a1';
+    const defaultSecondary = '#d1d1d1';
+    switch (edge) {
+      case 'top':
+        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorPrimaryHex : gameStream.awayTeam.colorPrimaryHex;
+        if (color === '') {
+          color = defaultPrimary;
+        }
+        break;
+      case 'left':
+        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
+          color = gameStream.homeTeam.colorSecondaryHex !== '' ? gameStream.homeTeam.colorSecondaryHex : defaultSecondary;
+        } else {
+          color = gameStream.awayTeam.colorPrimaryHex !== '' ? gameStream.awayTeam.colorPrimaryHex : defaultPrimary;
+        }
+        break;
+      case 'right':
+        if (gameStream.nextPlay.teamId === gameStream.homeTeam.id) {
+          color = gameStream.homeTeam.colorPrimaryHex !== '' ? gameStream.homeTeam.colorPrimaryHex : defaultPrimary;
+        } else {
+          color = gameStream.awayTeam.colorSecondaryHex !== '' ? gameStream.awayTeam.colorSecondaryHex : defaultSecondary;
+        }
+        break;
+      case 'bottom':
+        color = gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.homeTeam.colorSecondaryHex : gameStream.awayTeam.colorSecondaryHex;
+        if (color === '') {
+          color = defaultSecondary;
+        }
+        break;
+      default:
+        break;
+    }
+    return color !== '' ? color : '#a1a1a1';
+  };
+
+  return (
+    <div className={`gamestream-field ${slim && 'gsf-slim'}`}>
+      {gameStream.nextPlay.down > 0 && toGain && <div className="gsf-to-gain" style={{ left: 300 + gameStream.nextPlay.toGain * 5 }} />}
+      {ballOn && (
+        <div
+          className="gsf-ball-on"
+          style={{
+            left: 300 + gameStream.nextPlay.fieldPositionStart * 5,
+          }}
+        />
+      )}
+      {drive && (
+        <div
+          className="gsf-drive"
+          style={{
+            left: 300 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
+            width: Math.max(gameStream.driveYards, 0) * 5,
+            borderTop: `${slim ? 19 : 132}px solid ${driveFillColor('top')}`,
+            borderRight: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('right')}`,
+            borderBottom: `${slim ? 19 : 132}px solid ${driveFillColor('bottom')}`,
+            borderLeft: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('left')}`,
+          }}
+        />
+      )}
+      <div
+        className="gsf-home-team-endzone"
+        style={{
+          background: `linear-gradient(${gameStream.homeTeam.colorPrimaryHex} 25%, ${gameStream.homeTeam.colorSecondaryHex} 75%)`,
+        }}
+      >
+        {!slim && <p>{gameStream.homeTeam.nickname}</p>}
+      </div>
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div className="gsf-yardline" />
+      <div
+        className="gsf-away-team-endzone"
+        style={{
+          background: `linear-gradient(${gameStream.awayTeam.colorPrimaryHex} 25%, ${gameStream.awayTeam.colorSecondaryHex} 75%)`,
+        }}
+      >
+        {!slim && <p>{gameStream.awayTeam.nickname}</p>}
+      </div>
+    </div>
+  );
+}
+
+GameStreamField.propTypes = {
+  slim: PropTypes.bool,
+  drive: PropTypes.bool,
+  toGain: PropTypes.bool,
+  ballOn: PropTypes.bool,
+  playSegment: PropTypes.shape({
+    index: PropTypes.number,
+    fieldStart: PropTypes.number,
+    fieldEnd: PropTypes.number,
+    teamId: PropTypes.number,
+    segmentText: PropTypes.string,
+    lineType: PropTypes.string,
+    endpointType: PropTypes.string,
+  }).isRequired,
+};
+
+// GameStreamField.Drive = function Drive () {
+//   return (
+//     <div
+//           className="gsf-drive"
+//           style={{
+//             left: 300 + (gameStream.nextPlay.teamId === gameStream.homeTeam.id ? gameStream.drivePositionStart : gameStream.drivePositionStart - gameStream.driveYards) * 5,
+//             width: Math.max(gameStream.driveYards, 0) * 5,
+//             borderTop: `132px solid ${driveFillColor('top')}`,
+//             borderRight: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('right')}`,
+//             borderBottom: `132px solid ${driveFillColor('bottom')}`,
+//             borderLeft: `${(Math.max(gameStream.driveYards, 0) / 2) * 5}px solid ${driveFillColor('left')}`,
+//           }}
+//         />
+//   )
+// }

--- a/src/components/PlaySegment.js
+++ b/src/components/PlaySegment.js
@@ -1,22 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import GameStreamField from './GameStreamField';
 
 export default function PlaySegment({ playSegment }) {
   return (
     <div className="play-segment">
       {playSegment.fieldEnd != null && (
-        <div className="gamestream-field" style={{ height: '40px' }}>
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
-          <div className="gsf-yardline" />
+        <GameStreamField slim>
           <div
             className="play-segment-line"
             style={{
@@ -30,7 +20,7 @@ export default function PlaySegment({ playSegment }) {
               left: 300 - 4 + playSegment.fieldEnd * 5,
             }}
           />
-        </div>
+        </GameStreamField>
       )}
       <p className="play-segment-text">{playSegment.segmentText}</p>
     </div>

--- a/src/components/StatBar.js
+++ b/src/components/StatBar.js
@@ -76,6 +76,11 @@ StatBar.Ticker = function Ticker({ teamStats, lastPlay }) {
           <StatBar.Defender key={player.playerId} player={player} />
         ))}
       {teamStats
+        .filter((player) => lastPlay.fumbles.some((f) => [f.fumbleCommittedById, f.fumbleForcedById, f.fumbleRecoveredById].includes(player.playerId)))
+        .map((player) => (
+          <StatBar.Fumble key={player.playerId} player={player} />
+        ))}
+      {teamStats
         .filter((player) => player.playerId === lastPlay.extraPointKickerId)
         .map((player) => (
           <StatBar.Kicker key={player.playerId} player={player} />
@@ -100,6 +105,13 @@ StatBar.Ticker.propTypes = {
     tacklerIds: PropTypes.arrayOf(PropTypes.number),
     interceptedById: PropTypes.number,
     extraPointKickerId: PropTypes.number,
+    fumbles: PropTypes.arrayOf(
+      PropTypes.shape({
+        fumbleCommittedById: PropTypes.number,
+        fumbleForcedById: PropTypes.number,
+        fumbleRecoveredById: PropTypes.number,
+      }),
+    ),
   }).isRequired,
 };
 
@@ -361,5 +373,39 @@ StatBar.Returner.propTypes = {
     kickoffReturnYards: PropTypes.number,
     puntReturns: PropTypes.number,
     puntReturnYards: PropTypes.number,
+  }).isRequired,
+};
+
+StatBar.Fumble = function Fumble({ player }) {
+  return (
+    <div className="sb-header-item">
+      <span className="sbhi-player-name">
+        {player.playerInfo.firstName[0]}. {player.playerInfo.lastName}
+      </span>
+      <span className="sbhi-stat thin">
+        {player.fumblesCommitted}
+        <span className="sbhi-units">FUM</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.fumblesForced}
+        <span className="sbhi-units">FF</span>
+      </span>
+      <span className="sbhi-stat thin">
+        {player.fumblesRecovered}
+        <span className="sbhi-units">FR</span>
+      </span>
+    </div>
+  );
+};
+
+StatBar.Fumble.propTypes = {
+  player: PropTypes.shape({
+    playerInfo: PropTypes.shape({
+      firstName: PropTypes.string,
+      lastName: PropTypes.string,
+    }),
+    fumblesCommitted: PropTypes.number,
+    fumblesForced: PropTypes.number,
+    fumblesRecovered: PropTypes.number,
   }).isRequired,
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -765,9 +765,11 @@ body {
         .sb-header-item {
           display: flex;
           gap: 1px;
-          margin: 3px 8px;
+          margin: 3px 8px 0;
+          padding-bottom: 2px;
           justify-content: right;
           font-size: 0.8rem;
+          border-bottom: 1px solid rgba(172, 255, 47, 0.696);
           .sbhi-player-name {
             font-weight: bold;
             text-align: left;
@@ -789,6 +791,9 @@ body {
           .sbhi-stat.wide {
             min-width: 70px;
           }
+        }
+        .sb-header-item:last-of-type {
+          border: none;
         }
       }
       .stat-bar-section-divider {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -577,6 +577,17 @@ body {
         font-weight: bold;
       }
     }
+    .gsdi-upper {
+      position: relative;
+      top: 0;
+      display: flex;
+      width: 100%;
+      justify-content: center;
+      p, h4 {
+        width: auto;
+        margin: 0 10px;
+      }
+    }
   }
   .gamestream-field {
     position: relative;
@@ -647,6 +658,9 @@ body {
         transform: rotate(-180deg);
       }
     }
+  }
+  .gsf-slim {
+    height: 40px;
   }
   .gs-last-play {
     width: 800px;

--- a/src/utils/context/gameStreamContext.js.js
+++ b/src/utils/context/gameStreamContext.js.js
@@ -1,0 +1,85 @@
+// Context API Docs: https://beta.reactjs.org/learn/passing-data-deeply-with-context
+
+'use client';
+
+import React, { createContext, useContext } from 'react';
+import PropTypes from 'prop-types';
+
+const GameStreamContext = createContext();
+
+GameStreamContext.displayName = 'GameStreamContext'; // Context object accepts a displayName string property. React DevTools uses this string to determine what to display for the context. https://reactjs.org/docs/context.html#contextdisplayname
+
+function GameStreamProvider({ gameStream, children }) {
+  return <GameStreamContext.Provider value={gameStream}>{children}</GameStreamContext.Provider>;
+}
+
+const useGameStream = () => {
+  const context = useContext(GameStreamContext);
+
+  if (context === undefined) {
+    throw new Error('useGameStream must be used within a GameStreamProvider');
+  }
+  return context;
+};
+
+export { GameStreamProvider, useGameStream };
+
+GameStreamProvider.propTypes = {
+  children: PropTypes.node,
+  gameStream: PropTypes.shape({
+    homeTeam: PropTypes.shape({
+      id: PropTypes.number,
+      locationName: PropTypes.string,
+      nickname: PropTypes.string,
+      homeField: PropTypes.string,
+      homeLocation: PropTypes.string,
+      colorPrimaryHex: PropTypes.string,
+      colorSecondaryHex: PropTypes.string,
+    }),
+    homeTeamPlayerStats: PropTypes.shape,
+    homeTeamScore: PropTypes.number,
+    awayTeam: PropTypes.shape({
+      id: PropTypes.number,
+      locationName: PropTypes.string,
+      nickname: PropTypes.string,
+      colorPrimaryHex: PropTypes.string,
+      colorSecondaryHex: PropTypes.string,
+    }),
+    awayTeamPlayerStats: PropTypes.shape,
+    awayTeamScore: PropTypes.number,
+    drivePlays: PropTypes.number,
+    drivePositionStart: PropTypes.number,
+    driveYards: PropTypes.number,
+    driveTime: PropTypes.number,
+    lastPlay: PropTypes.shape({
+      teamId: PropTypes.number,
+      fieldPositionStart: PropTypes.number,
+      fieldPositionEnd: PropTypes.number,
+      down: PropTypes.number,
+      toGain: PropTypes.number,
+      clockStart: PropTypes.number,
+      clockEnd: PropTypes.number,
+      gamePeriod: PropTypes.number,
+      notes: PropTypes.string,
+      playSegments: PropTypes.arrayOf(
+        PropTypes.shape({
+          index: PropTypes.number,
+          fieldStart: PropTypes.number,
+          fieldEnd: PropTypes.number,
+          teamId: PropTypes.number,
+          segmentText: PropTypes.string,
+          lineType: PropTypes.string,
+          endpointType: PropTypes.string,
+        }),
+      ),
+    }),
+    nextPlay: PropTypes.shape({
+      teamId: PropTypes.number,
+      fieldPositionStart: PropTypes.number,
+      down: PropTypes.number,
+      toGain: PropTypes.number,
+      clockStart: PropTypes.number,
+      gamePeriod: PropTypes.number,
+    }),
+  }).isRequired,
+};


### PR DESCRIPTION
Created GameStreamField component break out of GameStream and PlaySegment components. Accepts drive, toGain, ballOn, and slim boolean props to handle display (all default to false).

GameStreamField and drive info in GameStream reorganize/compress when in expanded stats view of StatBar.

Created gameStreamProvider to create GameStreamContext. Implemented GameStreamContext within GameStream component to encapsulate GameStreamField and PlaySegment(s).

Added StatBar.Fumble subcomponent for use in StatBar.Ticker on fumbles.