### PR TITLE
Created DeletePlayModal to add confirmation step to play deletion

### DIFF
--- a/src/app/games/[gameId]/game-stream/page.js
+++ b/src/app/games/[gameId]/game-stream/page.js
@@ -10,11 +10,13 @@ import GameStream from '../../../../components/GameStream';
 import Loading from '../../../../components/Loading';
 import { useAuth } from '../../../../utils/context/authContext';
 import { deletePlay } from '../../../../api/playData';
+import DeletePlayModal from '../../../../components/modals/DeletePlayModal';
 
 export default function ManageGameStream({ params }) {
   const { gameId } = params;
   const [gameStream, setGameStream] = useState({});
   const [formStatus, setFormStatus] = useState('');
+  const [checkDelete, setCheckDelete] = useState(false);
   const { user } = useAuth();
 
   const updateGameStream = () => {
@@ -32,6 +34,13 @@ export default function ManageGameStream({ params }) {
     deletePlay(gameStream.lastPlay.id, user.sessionKey).then(() => {
       updateGameStream();
     });
+  };
+
+  const hideModal = (confirmDelete) => {
+    if (confirmDelete === 'confirm') {
+      handlePlayDelete();
+    }
+    setCheckDelete(false);
   };
 
   useEffect(() => {
@@ -54,9 +63,10 @@ export default function ManageGameStream({ params }) {
             <button className="button" type="button" onClick={() => setFormStatus('edit')}>
               Edit Last Play
             </button>
-            <button className="button button-red" type="button" onClick={handlePlayDelete} disabled={!gameStream.lastPlay.id > 0}>
+            <button className="button button-red" type="button" onClick={() => setCheckDelete(true)} disabled={!gameStream.lastPlay.id > 0}>
               Delete Last Play
             </button>
+            {checkDelete && <DeletePlayModal onClose={hideModal} />}
           </div>
         </div>
       )}

--- a/src/components/modals/DeletePlayModal.js
+++ b/src/components/modals/DeletePlayModal.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ModalWrapper from './ModalWrapper';
+
+export default function DeletePlayModal({ onClose }) {
+  return (
+    <ModalWrapper onHide={onClose}>
+      <div className="delete-play-modal std-mod">
+        <p className="dp-mod-text">Are you sure you want to delete the last play? This action cannot be undone.</p>
+        <div className="dp-mod-buttons">
+          <button type="button" className="button" onClick={() => onClose('abort')}>
+            Abort
+          </button>
+          <button type="button" className="button button-red" onClick={() => onClose('confirm')}>
+            Confirm Delete
+          </button>
+        </div>
+      </div>
+    </ModalWrapper>
+  );
+}
+
+DeletePlayModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+};

--- a/src/components/modals/FullStatsModal.js
+++ b/src/components/modals/FullStatsModal.js
@@ -6,7 +6,7 @@ import Stat from '../Stat';
 export default function FullStatsModal({ player, onClose }) {
   return (
     <ModalWrapper onHide={onClose}>
-      <div className="full-stats-modal">
+      <div className="full-stats-modal std-mod">
         <div className="fs-mod-header">
           <h3 className="fs-mod-header-player">
             {player.playerInfo.firstName} {player.playerInfo.lastName}
@@ -111,7 +111,7 @@ export default function FullStatsModal({ player, onClose }) {
           )}
         </div>
         {/* To satisfy FocusTrap component in wrapper, accessibility, though clicking anywhere will close */}
-        <button type="button" className="button button-red">
+        <button type="button" className="button button-red" onClick={onClose}>
           Close
         </button>
       </div>

--- a/src/components/modals/ModalWrapper.js
+++ b/src/components/modals/ModalWrapper.js
@@ -3,6 +3,12 @@ import PropTypes from 'prop-types';
 import { FocusTrap } from '@ciceksepeti/cui';
 
 export default function ModalWrapper({ children, onHide = null }) {
+  const handleClick = (e) => {
+    if (e.target.id === 'modal-backdrop') {
+      onHide();
+    }
+  };
+
   const handleKeyDown = (e) => {
     if (e.key === 'Escape') {
       onHide();
@@ -12,7 +18,7 @@ export default function ModalWrapper({ children, onHide = null }) {
   return (
     <div className="modal-trap-wrapper">
       <FocusTrap as="div">
-        <div role="button" className="modal-backdrop" onClick={onHide} onKeyDown={handleKeyDown} tabIndex={0}>
+        <div role="button" className="modal-backdrop" id="modal-backdrop" onClick={handleClick} onKeyDown={handleKeyDown} tabIndex={0}>
           {children}
         </div>
       </FocusTrap>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -875,17 +875,21 @@ body {
   }
 }
 
-.full-stats-modal {
+.std-mod {
   position: relative;
   top: 20vh;
   margin: auto;
   width: fit-content;
+  max-width: 100vw;
   height: fit-content;
   background: #212121;
   border: 2px solid greenyellow;
   border-radius: 5px;
   box-shadow: 5px 5px 3px -2px black;
   padding: 5px 10px;
+}
+
+.full-stats-modal {
   .fs-mod-header {
     width: max-content;
     margin: auto;
@@ -913,6 +917,18 @@ body {
   }
   button {
     margin-top: 5px;
+  }
+}
+
+.delete-play-modal {
+  max-width: 400px;
+  .dp-mod-text {
+    font-size: 0.8rem;
+  }
+  .dp-mod-buttons {
+    display: flex;
+    justify-content: space-evenly;
+    margin-bottom: 5px;
   }
 }
 


### PR DESCRIPTION
Created DeletePlayModal.

Clicking 'Delete Last Play' button on /games/[gameId]/game-stream page shows DeletePlayModal asking for confirmation before deletion of the play. User can abort or confirm the deletion. Clicking the modal backdrop will also close the modal without deleting the play.

Refactored ModalWrapper to only close on click if the click targets the backdrop element.

Added functionality to 'Close' button in FullStatsModal.

Created std-modal class to handle basic modal styling, derived from FullStatsModal