### PR TITLE
v1.025.0130.1 Bug Fixes

### DIFF
--- a/src/app/games/[gameId]/game-stream/page.js
+++ b/src/app/games/[gameId]/game-stream/page.js
@@ -61,18 +61,22 @@ export default function ManageGameStream({ params }) {
             <button className="button" type="button" onClick={() => setFormStatus('new')}>
               Next Play
             </button>
-            <button className="button" type="button" onClick={() => setFormStatus('edit')}>
-              Edit Last Play
-            </button>
-            <button className="button button-red" type="button" onClick={() => setCheckDelete(true)} disabled={!gameStream.lastPlay.id > 0}>
-              Delete Last Play
-            </button>
-            {checkDelete && <DeletePlayModal onClose={hideModal} />}
+            {gameStream.nextPlay.prevPlayId > 0 && (
+              <>
+                <button className="button" type="button" onClick={() => setFormStatus('edit')}>
+                  Edit Last Play
+                </button>
+                <button className="button button-red" type="button" onClick={() => setCheckDelete(true)} disabled={!gameStream.lastPlay.id > 0}>
+                  Delete Last Play
+                </button>
+                {checkDelete && <DeletePlayModal onClose={hideModal} />}
+              </>
+            )}
           </div>
         </div>
       )}
       <PlayForm key={0} gameId={parseInt(gameId, 10)} onUpdate={hideForm} playEdit={gameStream?.nextPlay} homeTeam={gameStream?.homeTeam} awayTeam={gameStream?.awayTeam} visible={formStatus === 'new'} />
-      <PlayForm key={gameStream?.lastPlay.id} gameId={parseInt(gameId, 10)} onUpdate={hideForm} playEdit={gameStream?.lastPlay} homeTeam={gameStream?.homeTeam} awayTeam={gameStream?.awayTeam} visible={formStatus === 'edit'} />
+      {gameStream.nextPlay.prevPlayId > 0 && <PlayForm key={gameStream?.lastPlay.id} gameId={parseInt(gameId, 10)} onUpdate={hideForm} playEdit={gameStream?.lastPlay} homeTeam={gameStream?.homeTeam} awayTeam={gameStream?.awayTeam} visible={formStatus === 'edit'} />}
     </GameStreamProvider>
   );
 }

--- a/src/app/watch/[gameId]/page.js
+++ b/src/app/watch/[gameId]/page.js
@@ -7,6 +7,7 @@ import { getGameStream } from '../../../api/gameData';
 import GameStream from '../../../components/GameStream';
 import Loading from '../../../components/Loading';
 import { clientCredentials } from '../../../utils/client';
+import { GameStreamProvider } from '../../../utils/context/gameStreamContext';
 
 export default function WatchGameStream({ params }) {
   const { gameId } = params;
@@ -36,10 +37,10 @@ export default function WatchGameStream({ params }) {
   }
 
   return (
-    <>
+    <GameStreamProvider gameStream={gameStream}>
       {connection == null && <p>Attempting to establish connection...</p>}
-      <GameStream gameStream={gameStream} />;
-    </>
+      <GameStream />
+    </GameStreamProvider>
   );
 }
 

--- a/src/components/GameStream.js
+++ b/src/components/GameStream.js
@@ -43,7 +43,8 @@ export default function GameStream() {
         <div className="gs-status-home-poss">{gameStream.nextPlay.teamId === gameStream.homeTeam.id && <h2>●</h2>}</div>
         <div className="gs-status-info">
           <p className="gssi-clock">
-            Q{gameStream.nextPlay.gamePeriod}
+            <span className="txt-gy">Q</span>
+            {gameStream.nextPlay.gamePeriod}
             &emsp;
             {Math.floor(gameStream.nextPlay.clockStart / 60)}:{(gameStream.nextPlay.clockStart % 60).toString().padStart(2, '0')}
           </p>

--- a/src/components/forms/PlayForm.js
+++ b/src/components/forms/PlayForm.js
@@ -113,48 +113,6 @@ const initialDisplay = {
   penaltyCreator: false,
 };
 
-// const retainPlay = {
-//   passerId: null,
-//   receiverId: null,
-//   completion: false,
-//   rusherId: null,
-//   tacklerIds: [],
-//   passDefenderIds: [],
-//   kickoff: false,
-//   punt: false,
-//   fieldGoal: false,
-//   kickerId: null,
-//   kickReturnerId: null,
-//   kickFieldedAt: null,
-//   kickFairCatch: false,
-//   kickGood: false,
-//   kickTouchback: false,
-//   kickFake: false,
-//   touchdownPlayerId: null,
-//   extraPoint: false,
-//   conversion: false,
-//   extraPointKickerId: null,
-//   extraPointGood: false,
-//   extraPointFake: false,
-//   conversionPasserId: null,
-//   conversionReceiverId: null,
-//   conversionRusherId: null,
-//   conversionGood: false,
-//   defensiveConversion: false,
-//   conversionReturnerId: null,
-//   safety: false,
-//   cedingPlayerId: null,
-//   fumbles: [],
-//   interceptedById: null,
-//   interceptedAt: null,
-//   kickBlocked: false,
-//   kickBlockedById: null,
-//   kickBlockRecoveredById: null,
-//   kickBlockRecoveredAt: null,
-//   laterals: [],
-//   penalties: [],
-// };
-
 export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdit = initialState, visible = true }) {
   const [formData, setFormData] = useState({});
   const [validatedFormData, setValidatedFormData] = useState(initialState);
@@ -231,6 +189,14 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
     const resetValues = {};
     keys.forEach((key) => {
       resetValues[key] = playEdit[key] || initialState[key];
+    });
+    setFormData((prev) => ({ ...prev, ...resetValues }));
+  };
+
+  const selectiveDataFalse = (keys = []) => {
+    const resetValues = {};
+    keys.forEach((key) => {
+      resetValues[key] = false;
     });
     setFormData((prev) => ({ ...prev, ...resetValues }));
   };
@@ -1038,7 +1004,7 @@ export default function PlayForm({ gameId, homeTeam, awayTeam, onUpdate, playEdi
                   checked={formDisplay?.interception}
                   onClick={(e) => {
                     handleDisplay(e);
-                    selectiveReset(['completion']);
+                    selectiveDataFalse(['completion']);
                   }}
                 >
                   INTERCEPTION


### PR DESCRIPTION
#34 moved GameStreamProvider scope to page.js from the GameStream component, this required adding GameStreamProvider to /watch/[gameId] page.js as well.

selectiveReset function in PlayForm returns a single FormData element to its initial state, but in the case of editing a play, its initial state may not be null. So when switching between Completion and Interception, if the edited play was a completion, clicking Interception would set Completion to true rather than to false. Created new function selectiveDataFalse to use in this case, PlayForm needs refactoring for more expansive use of this function.

When starting a game, the edit last play PlayForm and button rely on the last play not being null. But when starting a game, there is no last play. Added gates to /games/[gameId]/game-stream page to avoid attempting to render these items when the prevPlayId <= 0 (prevPlayId = -1 on initial Play).